### PR TITLE
fix: persist appearance and typography preferences across restarts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "markdown-viewer",
   "productName": "Open Markdown",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "A macOS desktop markdown viewer with GitHub-style rendering and plugin support",
   "main": ".vite/build/index.js",
   "private": true,

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -273,10 +273,12 @@ class App {
         },
       });
 
-      // Load initial preferences
+      // Load initial preferences and re-apply theme so typography/colors take effect
       const preferences = await window.electronAPI.preferences.get();
       this.state.currentPreferences = preferences.core;
+      this.state.currentTheme = preferences.core.theme.mode;
       this.preferencesPanel.updateValues(preferences);
+      await this.applyTheme(this.state.currentTheme);
 
       // Load plugin preference schemas
       const pluginSchemas = this.markdownViewer?.getPluginPreferencesSchemas();
@@ -746,9 +748,10 @@ class App {
       // Update current preferences state
       this.state.currentPreferences = updatedPrefs.core;
 
-      // Update theme mode if changed
+      // Update theme mode if changed — sync to ThemeService so it persists on restart
       if (updates.core?.theme?.mode) {
         this.state.currentTheme = updates.core.theme.mode;
+        await window.electronAPI.theme.set(updates.core.theme.mode);
       }
 
       // Notify plugins of preference changes


### PR DESCRIPTION
Two bugs prevented preferences from surviving an app restart:

1. Theme mode set via the Preferences panel wrote only to PreferencesService (preferences.json) but on launch the app read from ThemeService (theme-preferences.json). The two stores were never synchronized, so the saved mode was ignored on next launch. Fix: sync the theme mode to ThemeService when changed via the Preferences panel.

2. Font size and other typography settings were saved correctly to preferences.json but never applied on startup. initializeTheme() ran before initializePreferences(), so applyTheme() rendered CSS with null preferences (defaults). Fix: re-apply the theme after loading preferences so saved typography values take effect.