### PR TITLE
Add Notion-style edit mode with inline markdown editing

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,18 @@
         </div>
         <div class="toolbar-right">
           <div class="toolbar-spacer"></div>
+          <!-- Edit Mode Toggle -->
+          <button id="edit-mode-btn" class="toolbar-btn" title="Enter edit mode" disabled>
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168l10-10zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207 11.207 2.5zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293l6.5-6.5zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"/>
+            </svg>
+          </button>
+          <!-- Save Button (visible when auto-save is off) -->
+          <button id="save-btn" class="toolbar-btn hidden" title="Save (Cmd+S)" disabled>
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M2 1a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H9.5a1 1 0 0 0-1 1v7.293l2.146-2.147a.5.5 0 0 1 .708.708l-3 3a.5.5 0 0 1-.708 0l-3-3a.5.5 0 1 1 .708-.708L7.5 9.293V2a2 2 0 0 1 2-2H14a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h2.5a.5.5 0 0 1 0 1H2z"/>
+            </svg>
+          </button>
           <!-- Copy Document Dropdown -->
           <div id="copy-dropdown" class="toolbar-dropdown">
             <button id="copy-dropdown-btn" class="toolbar-btn toolbar-btn-dropdown" title="Copy document" disabled>

--- a/index.html
+++ b/index.html
@@ -33,18 +33,26 @@
         </div>
         <div class="toolbar-right">
           <div class="toolbar-spacer"></div>
-          <!-- Edit Mode Toggle -->
-          <button id="edit-mode-btn" class="toolbar-btn" title="Enter edit mode" disabled>
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-              <path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168l10-10zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207 11.207 2.5zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293l6.5-6.5zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"/>
-            </svg>
-          </button>
-          <!-- Save Button (visible when auto-save is off) -->
-          <button id="save-btn" class="toolbar-btn hidden" title="Save (Cmd+S)" disabled>
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-              <path d="M2 1a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H9.5a1 1 0 0 0-1 1v7.293l2.146-2.147a.5.5 0 0 1 .708.708l-3 3a.5.5 0 0 1-.708 0l-3-3a.5.5 0 1 1 .708-.708L7.5 9.293V2a2 2 0 0 1 2-2H14a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h2.5a.5.5 0 0 1 0 1H2z"/>
-            </svg>
-          </button>
+          <!-- Edit / Save split button -->
+          <div id="edit-save-group" class="toolbar-dropdown edit-save-group">
+            <button id="edit-mode-btn" class="toolbar-btn edit-save-main" title="Enter edit mode" disabled>
+              <svg id="edit-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168l10-10zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207 11.207 2.5zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293l6.5-6.5zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"/>
+              </svg>
+              <svg id="save-icon" class="hidden" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M2 1a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H9.5a1 1 0 0 0-1 1v4.5h2a.5.5 0 0 1 .354.854l-2.5 2.5a.5.5 0 0 1-.708 0l-2.5-2.5A.5.5 0 0 1 5.5 5.5h2V2a2 2 0 0 1 2-2H14a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h2.5a.5.5 0 0 1 0 1H2z"/>
+              </svg>
+              <span id="edit-save-label">Edit</span>
+            </button>
+            <button id="edit-save-arrow" class="toolbar-btn edit-save-arrow hidden" title="More options">
+              <svg class="dropdown-chevron" width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
+                <path fill-rule="evenodd" d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/>
+              </svg>
+            </button>
+            <div id="edit-save-menu" class="dropdown-menu hidden">
+              <button id="cancel-edit-btn" class="dropdown-item">Cancel (discard changes)</button>
+            </div>
+          </div>
           <!-- Copy Document Dropdown -->
           <div id="copy-dropdown" class="toolbar-dropdown">
             <button id="copy-dropdown-btn" class="toolbar-btn toolbar-btn-dropdown" title="Copy document" disabled>

--- a/src/index.css
+++ b/src/index.css
@@ -1620,3 +1620,259 @@ button:focus:not(:focus-visible) {
   background-color: #ff9632;
   color: #000000;
 }
+
+/* ===========================
+   Edit Mode Styles
+   =========================== */
+
+/* Active toggle button */
+.toolbar-btn-active {
+  background-color: var(--active-bg);
+  border-color: var(--link-color);
+  color: var(--link-color);
+}
+
+.toolbar-btn-active:hover {
+  background-color: var(--active-bg);
+}
+
+/* Edit mode container */
+.markdown-body.edit-mode {
+  position: relative;
+}
+
+/* Slice wrapper */
+.slice {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  border-radius: 4px;
+  transition: background-color 0.15s ease;
+  margin-left: -40px;
+  padding-left: 0;
+}
+
+.slice:hover {
+  background-color: var(--hover-bg);
+}
+
+.slice:hover > .slice-handle {
+  opacity: 1;
+}
+
+/* Slice handle (left side, Notion-style grip) */
+.slice-handle {
+  position: relative;
+  flex-shrink: 0;
+  width: 32px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 4px;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.slice-handle-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: grab;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.slice-handle-btn:hover {
+  background-color: var(--active-bg);
+  color: var(--text-color);
+}
+
+.slice-handle-btn:active {
+  cursor: grabbing;
+}
+
+/* Slice content area */
+.slice-content {
+  flex: 1;
+  min-width: 0;
+  cursor: text;
+  border-radius: 4px;
+  padding: 2px 8px;
+  transition: box-shadow 0.15s ease;
+}
+
+.slice.slice-editing .slice-content {
+  box-shadow: 0 0 0 2px var(--link-color);
+  background-color: var(--bg-color);
+}
+
+/* Reset margins on rendered content inside slices */
+.slice-content > :first-child {
+  margin-top: 0;
+}
+
+.slice-content > :last-child {
+  margin-bottom: 0;
+}
+
+/* Slice editor textarea */
+.slice-editor {
+  width: 100%;
+  min-height: 40px;
+  padding: 8px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-color);
+  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  resize: none;
+  outline: none;
+  overflow: hidden;
+}
+
+.slice-editor:focus {
+  outline: none;
+}
+
+/* Slice options menu */
+.slice-menu {
+  position: absolute;
+  top: 28px;
+  left: 0;
+  z-index: 100;
+  min-width: 180px;
+  padding: 4px;
+  background: var(--bg-color);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+[data-theme="dark"] .slice-menu {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.slice-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 10px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-color);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.1s;
+}
+
+.slice-menu-item:hover {
+  background-color: var(--hover-bg);
+}
+
+.slice-menu-item-active {
+  background-color: var(--hover-bg);
+  color: var(--link-color);
+}
+
+.slice-menu-item svg {
+  flex-shrink: 0;
+  opacity: 0.6;
+}
+
+.slice-menu-item-danger {
+  color: var(--error-text);
+}
+
+.slice-menu-item-danger:hover {
+  background-color: var(--error-bg);
+}
+
+.slice-menu-divider {
+  height: 1px;
+  margin: 4px 0;
+  background-color: var(--border-color);
+}
+
+/* "Turn into" submenu trigger */
+.slice-menu-submenu-trigger {
+  position: relative;
+  justify-content: flex-start;
+}
+
+.slice-menu-chevron {
+  margin-left: auto;
+  opacity: 0.4;
+  flex-shrink: 0;
+}
+
+/* Submenu (appears on hover to the right) */
+.slice-submenu {
+  display: none;
+  position: absolute;
+  left: 100%;
+  top: -4px;
+  min-width: 180px;
+  padding: 4px;
+  background: var(--bg-color);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  z-index: 101;
+  margin-left: 4px;
+}
+
+[data-theme="dark"] .slice-submenu {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.slice-menu-submenu-trigger:hover > .slice-submenu {
+  display: block;
+}
+
+/* Block type badge (Aa, H1, H2, •, 1., etc.) */
+.slice-block-type-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  height: 20px;
+  padding: 0 4px;
+  font-size: 11px;
+  font-weight: 700;
+  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, monospace;
+  background: var(--hover-bg);
+  border-radius: 3px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+/* Edit mode badge in status bar */
+.status-edit-mode {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--link-color);
+  font-weight: 500;
+}
+
+/* Smooth transition between view and edit modes */
+.markdown-body {
+  transition: padding-left 0.2s ease;
+}
+
+.markdown-body.edit-mode {
+  padding-left: 8px;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1625,7 +1625,56 @@ button:focus:not(:focus-visible) {
    Edit Mode Styles
    =========================== */
 
-/* Active toggle button */
+/* Edit / Save split button group */
+.edit-save-group {
+  display: inline-flex;
+  position: relative;
+}
+
+.edit-save-group.is-editing .edit-save-main {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  border-right: none;
+  background-color: var(--active-bg);
+  border-color: var(--link-color);
+  color: var(--link-color);
+}
+
+.edit-save-group.is-editing .edit-save-main:hover {
+  background-color: var(--hover-bg);
+}
+
+.edit-save-arrow {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  padding: 6px 6px;
+  border-color: var(--link-color);
+  color: var(--link-color);
+  background-color: var(--active-bg);
+}
+
+.edit-save-arrow:hover {
+  background-color: var(--hover-bg);
+}
+
+.edit-save-arrow .dropdown-chevron {
+  opacity: 0.6;
+  transition: transform 0.15s ease;
+}
+
+.edit-save-group.is-open .edit-save-arrow .dropdown-chevron {
+  transform: rotate(180deg);
+}
+
+.edit-save-group .dropdown-menu {
+  right: 0;
+  left: auto;
+  top: 100%;
+  margin-top: 4px;
+  min-width: 200px;
+}
+
+/* Active toggle button (generic) */
 .toolbar-btn-active {
   background-color: var(--active-bg);
   border-color: var(--link-color);
@@ -1633,7 +1682,7 @@ button:focus:not(:focus-visible) {
 }
 
 .toolbar-btn-active:hover {
-  background-color: var(--active-bg);
+  background-color: var(--hover-bg);
 }
 
 /* Edit mode container */

--- a/src/main/ipc/handlers/FileHandler.ts
+++ b/src/main/ipc/handlers/FileHandler.ts
@@ -8,7 +8,7 @@ import { getFileWatcherService } from '../../services/FileWatcherService';
 import { getWindowManager } from '@main/window/WindowManager';
 import { IPC_CHANNELS } from '../channels';
 
-import type { FileOpenResult, FileReadResult } from '@shared/types';
+import type { FileOpenResult, FileReadResult, FileWriteResult } from '@shared/types';
 
 // Track per-window subscription cleanup functions to prevent duplicate callbacks
 const windowSubscriptions = new Map<number, () => void>();
@@ -34,6 +34,14 @@ export function registerFileHandlers(): void {
     IPC_CHANNELS.FILE.READ,
     async (_event, filePath: string): Promise<FileReadResult> => {
       return fileService.readFile(filePath);
+    }
+  );
+
+  // Handle file write
+  ipcMain.handle(
+    IPC_CHANNELS.FILE.WRITE,
+    async (_event, filePath: string, content: string): Promise<FileWriteResult> => {
+      return fileService.writeFile(filePath, content);
     }
   );
 
@@ -104,6 +112,7 @@ export function registerFileHandlers(): void {
 export function unregisterFileHandlers(): void {
   ipcMain.removeHandler(IPC_CHANNELS.FILE.OPEN_DIALOG);
   ipcMain.removeHandler(IPC_CHANNELS.FILE.READ);
+  ipcMain.removeHandler(IPC_CHANNELS.FILE.WRITE);
   ipcMain.removeHandler(IPC_CHANNELS.FILE.WATCH);
   ipcMain.removeHandler(IPC_CHANNELS.FILE.UNWATCH);
 }

--- a/src/main/menu/applicationMenu.ts
+++ b/src/main/menu/applicationMenu.ts
@@ -52,6 +52,18 @@ export function setupApplicationMenu(): void {
           click: () => sendMenuAction('open-file'),
         },
         { type: 'separator' },
+        {
+          label: 'Save',
+          accelerator: 'CmdOrCtrl+S',
+          click: () => sendMenuAction('save'),
+        },
+        { type: 'separator' },
+        {
+          label: 'Toggle Edit Mode',
+          accelerator: 'CmdOrCtrl+E',
+          click: () => sendMenuAction('toggle-edit-mode'),
+        },
+        { type: 'separator' },
         { role: 'close' },
       ],
     },

--- a/src/main/services/FileService.ts
+++ b/src/main/services/FileService.ts
@@ -2,7 +2,7 @@
  * FileService - Handles file operations in the main process
  */
 import { dialog, BrowserWindow } from 'electron';
-import { readFile, stat } from 'node:fs/promises';
+import { readFile, writeFile, stat } from 'node:fs/promises';
 import path from 'node:path';
 
 import { MARKDOWN_EXTENSIONS, MAX_FILE_SIZE_BYTES } from '@shared/constants';
@@ -12,7 +12,7 @@ import {
   InvalidFileTypeError,
 } from '@shared/errors';
 
-import type { FileOpenResult, FileReadResult, FileStats } from '@shared/types';
+import type { FileOpenResult, FileReadResult, FileWriteResult, FileStats } from '@shared/types';
 
 /**
  * Service for handling file operations
@@ -140,6 +140,19 @@ export class FileService {
         success: false,
         error: readError.toUserMessage(),
       };
+    }
+  }
+
+  /**
+   * Write content to a file
+   */
+  async writeFile(filePath: string, content: string): Promise<FileWriteResult> {
+    try {
+      await writeFile(filePath, content, 'utf-8');
+      return { success: true };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return { success: false, error: message };
     }
   }
 

--- a/src/preferences/defaults.ts
+++ b/src/preferences/defaults.ts
@@ -126,6 +126,10 @@ export const DEFAULT_CORE_PREFERENCES: CorePreferences = {
       itemSpacing: '0.25em',
     },
   },
+  editor: {
+    autoSave: true,
+    autoSaveDelay: 1000,
+  },
 };
 
 /**

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -12,6 +12,7 @@ import type {
   FileDeleteEvent,
   FileOpenResult,
   FileReadResult,
+  FileWriteResult,
   FullscreenChangeEvent,
   RecentFileEntry,
   ResolvedTheme,
@@ -37,6 +38,10 @@ const electronAPI: ElectronAPI = {
 
     read: (filePath: string): Promise<FileReadResult> => {
       return ipcRenderer.invoke(IPC_CHANNELS.FILE.READ, filePath);
+    },
+
+    write: (filePath: string, content: string): Promise<FileWriteResult> => {
+      return ipcRenderer.invoke(IPC_CHANNELS.FILE.WRITE, filePath, content);
     },
 
     watch: (filePath: string): Promise<void> => {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -241,11 +241,14 @@ class App {
       onOpenPreferences: () => {
         this.handleOpenPreferences();
       },
-      onToggleEditMode: () => {
-        void this.handleToggleEditMode();
+      onEnterEditMode: () => {
+        void this.handleEnterEditMode();
       },
       onSave: () => {
-        void this.handleManualSave();
+        void this.handleSaveAndExitEditMode();
+      },
+      onCancelEdit: () => {
+        void this.handleCancelEdit();
       },
     });
 
@@ -443,11 +446,15 @@ class App {
             break;
           case 'save':
             if (this.state.isEditMode) {
-              void this.handleManualSave();
+              void this.handleSaveAndExitEditMode();
             }
             break;
           case 'toggle-edit-mode':
-            void this.handleToggleEditMode();
+            if (this.state.isEditMode) {
+              void this.handleSaveAndExitEditMode();
+            } else {
+              void this.handleEnterEditMode();
+            }
             break;
         }
       }
@@ -536,12 +543,8 @@ class App {
   private async loadFile(filePath: string): Promise<void> {
     try {
       // Exit edit mode if active
-      if (this.state.isEditMode && this.markdownViewer) {
-        await this.markdownViewer.exitEditMode();
-        this.state.isEditMode = false;
-        this.state.hasUnsavedChanges = false;
-        this.toolbar?.setEditMode(false);
-        this.toolbar?.setSaveButtonVisible(false);
+      if (this.state.isEditMode) {
+        await this.exitEditMode();
       }
 
       // Stop watching previous file
@@ -725,80 +728,67 @@ class App {
   }
 
   /**
-   * Toggle edit mode on/off
+   * Enter edit mode
    */
-  private async handleToggleEditMode(): Promise<void> {
+  private async handleEnterEditMode(): Promise<void> {
     if (!this.markdownViewer || !this.state.currentFilePath) return;
 
-    if (this.state.isEditMode) {
-      // Exit edit mode
-      await this.markdownViewer.exitEditMode();
-      this.state.isEditMode = false;
-      this.toolbar?.setEditMode(false);
-      this.toolbar?.setSaveButtonVisible(false);
+    const callbacks: EditModeCallbacks = {
+      onContentChange: (_markdown: string) => {
+        this.state.hasUnsavedChanges = true;
+      },
+    };
+    await this.markdownViewer.enterEditMode(callbacks);
+    this.state.isEditMode = true;
+    this.toolbar?.setEditMode(true);
+  }
 
-      // Clear auto-save timer
-      if (this.autoSaveTimer) {
-        clearTimeout(this.autoSaveTimer);
-        this.autoSaveTimer = null;
-      }
+  /**
+   * Save changes and exit edit mode
+   */
+  private async handleSaveAndExitEditMode(): Promise<void> {
+    if (!this.markdownViewer) return;
 
-      // Save any pending changes
-      if (this.state.hasUnsavedChanges) {
-        await this.saveFile();
-      }
-    } else {
-      // Enter edit mode
-      const callbacks: EditModeCallbacks = {
-        onContentChange: (markdown: string) => {
-          this.handleEditContentChange(markdown);
-        },
-      };
-      await this.markdownViewer.enterEditMode(callbacks);
-      this.state.isEditMode = true;
-      this.toolbar?.setEditMode(true);
+    // Save before exiting
+    if (this.state.hasUnsavedChanges) {
+      await this.saveFile();
+    }
 
-      // Show save button if auto-save is disabled
-      const autoSave = this.state.currentPreferences?.editor?.autoSave ?? true;
-      if (!autoSave) {
-        this.toolbar?.setSaveButtonVisible(true);
-        this.toolbar?.setSaveButtonEnabled(false);
-      }
+    await this.exitEditMode();
+  }
+
+  /**
+   * Cancel edit mode - discard unsaved changes and re-render from disk
+   */
+  private async handleCancelEdit(): Promise<void> {
+    if (!this.markdownViewer || !this.state.currentFilePath) return;
+
+    // Discard changes - exit without saving
+    this.state.hasUnsavedChanges = false;
+    await this.exitEditMode();
+
+    // Re-read from disk to restore original content
+    const result = await window.electronAPI.file.read(this.state.currentFilePath);
+    if (result.success && result.content != null) {
+      await this.markdownViewer.render(result.content, this.state.currentFilePath);
     }
   }
 
   /**
-   * Handle content changes during edit mode
+   * Common exit-edit-mode cleanup
    */
-  private handleEditContentChange(markdown: string): void {
-    this.state.hasUnsavedChanges = true;
+  private async exitEditMode(): Promise<void> {
+    if (!this.markdownViewer) return;
 
-    const autoSave = this.state.currentPreferences?.editor?.autoSave ?? true;
-    const autoSaveDelay = this.state.currentPreferences?.editor?.autoSaveDelay ?? 1000;
+    await this.markdownViewer.exitEditMode();
+    this.state.isEditMode = false;
+    this.state.hasUnsavedChanges = false;
+    this.toolbar?.setEditMode(false);
 
-    if (autoSave) {
-      // Debounced auto-save
-      if (this.autoSaveTimer) {
-        clearTimeout(this.autoSaveTimer);
-      }
-      this.autoSaveTimer = setTimeout(() => {
-        void this.saveFile();
-      }, autoSaveDelay);
-    } else {
-      // Enable save button
-      this.toolbar?.setSaveButtonEnabled(true);
+    if (this.autoSaveTimer) {
+      clearTimeout(this.autoSaveTimer);
+      this.autoSaveTimer = null;
     }
-
-    // Update the diff service baseline for the gutter
-    this.diffService?.setBaseline(markdown);
-  }
-
-  /**
-   * Handle manual save (when auto-save is off)
-   */
-  private async handleManualSave(): Promise<void> {
-    await this.saveFile();
-    this.toolbar?.setSaveButtonEnabled(false);
   }
 
   /**

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -27,6 +27,7 @@ import {
   type FindBar,
   type RecentFilesDropdown,
 } from './renderer/components';
+import type { EditModeCallbacks } from './renderer/components/EditModeController';
 import {
   createDocumentCopyService,
   DiffService,
@@ -59,6 +60,8 @@ interface AppState {
   currentPreferences: CorePreferences | null;
   isWatching: boolean;
   isFullscreen: boolean;
+  isEditMode: boolean;
+  hasUnsavedChanges: boolean;
 }
 
 /**
@@ -86,7 +89,11 @@ class App {
     currentPreferences: null,
     isWatching: false,
     isFullscreen: false,
+    isEditMode: false,
+    hasUnsavedChanges: false,
   };
+
+  private autoSaveTimer: ReturnType<typeof setTimeout> | null = null;
 
   private cleanupFunctions: Array<() => void> = [];
   private contentRenderTimer: ReturnType<typeof setTimeout> | null = null;
@@ -233,6 +240,12 @@ class App {
       },
       onOpenPreferences: () => {
         this.handleOpenPreferences();
+      },
+      onToggleEditMode: () => {
+        void this.handleToggleEditMode();
+      },
+      onSave: () => {
+        void this.handleManualSave();
       },
     });
 
@@ -428,6 +441,14 @@ class App {
           case 'zoom-reset':
             this.zoomController?.resetZoom();
             break;
+          case 'save':
+            if (this.state.isEditMode) {
+              void this.handleManualSave();
+            }
+            break;
+          case 'toggle-edit-mode':
+            void this.handleToggleEditMode();
+            break;
         }
       }
     );
@@ -460,6 +481,10 @@ class App {
 
     // Disable copy dropdown when no document
     this.copyDropdown?.setEnabled(false);
+
+    // Disable edit mode button
+    const editModeBtn = document.getElementById('edit-mode-btn') as HTMLButtonElement | null;
+    if (editModeBtn) editModeBtn.disabled = true;
   }
 
   /**
@@ -474,6 +499,10 @@ class App {
 
     // Enable copy dropdown when document is loaded
     this.copyDropdown?.setEnabled(true);
+
+    // Enable edit mode button
+    const editModeBtn = document.getElementById('edit-mode-btn') as HTMLButtonElement | null;
+    if (editModeBtn) editModeBtn.disabled = false;
   }
 
   /**
@@ -506,6 +535,15 @@ class App {
    */
   private async loadFile(filePath: string): Promise<void> {
     try {
+      // Exit edit mode if active
+      if (this.state.isEditMode && this.markdownViewer) {
+        await this.markdownViewer.exitEditMode();
+        this.state.isEditMode = false;
+        this.state.hasUnsavedChanges = false;
+        this.toolbar?.setEditMode(false);
+        this.toolbar?.setSaveButtonVisible(false);
+      }
+
       // Stop watching previous file
       if (this.state.currentFilePath && this.state.isWatching) {
         await this.stopWatching();
@@ -595,6 +633,9 @@ class App {
   private async handleFileChange(event: FileChangeEvent): Promise<void> {
     if (event.filePath !== this.state.currentFilePath) return;
 
+    // In edit mode, ignore external changes to avoid conflicts
+    if (this.state.isEditMode) return;
+
     try {
       // Update modified time
       this.statusBar?.setModifiedTime(new Date());
@@ -681,6 +722,109 @@ class App {
    */
   private handleOpenPreferences(): void {
     this.preferencesPanel?.open();
+  }
+
+  /**
+   * Toggle edit mode on/off
+   */
+  private async handleToggleEditMode(): Promise<void> {
+    if (!this.markdownViewer || !this.state.currentFilePath) return;
+
+    if (this.state.isEditMode) {
+      // Exit edit mode
+      await this.markdownViewer.exitEditMode();
+      this.state.isEditMode = false;
+      this.toolbar?.setEditMode(false);
+      this.toolbar?.setSaveButtonVisible(false);
+
+      // Clear auto-save timer
+      if (this.autoSaveTimer) {
+        clearTimeout(this.autoSaveTimer);
+        this.autoSaveTimer = null;
+      }
+
+      // Save any pending changes
+      if (this.state.hasUnsavedChanges) {
+        await this.saveFile();
+      }
+    } else {
+      // Enter edit mode
+      const callbacks: EditModeCallbacks = {
+        onContentChange: (markdown: string) => {
+          this.handleEditContentChange(markdown);
+        },
+      };
+      await this.markdownViewer.enterEditMode(callbacks);
+      this.state.isEditMode = true;
+      this.toolbar?.setEditMode(true);
+
+      // Show save button if auto-save is disabled
+      const autoSave = this.state.currentPreferences?.editor?.autoSave ?? true;
+      if (!autoSave) {
+        this.toolbar?.setSaveButtonVisible(true);
+        this.toolbar?.setSaveButtonEnabled(false);
+      }
+    }
+  }
+
+  /**
+   * Handle content changes during edit mode
+   */
+  private handleEditContentChange(markdown: string): void {
+    this.state.hasUnsavedChanges = true;
+
+    const autoSave = this.state.currentPreferences?.editor?.autoSave ?? true;
+    const autoSaveDelay = this.state.currentPreferences?.editor?.autoSaveDelay ?? 1000;
+
+    if (autoSave) {
+      // Debounced auto-save
+      if (this.autoSaveTimer) {
+        clearTimeout(this.autoSaveTimer);
+      }
+      this.autoSaveTimer = setTimeout(() => {
+        void this.saveFile();
+      }, autoSaveDelay);
+    } else {
+      // Enable save button
+      this.toolbar?.setSaveButtonEnabled(true);
+    }
+
+    // Update the diff service baseline for the gutter
+    this.diffService?.setBaseline(markdown);
+  }
+
+  /**
+   * Handle manual save (when auto-save is off)
+   */
+  private async handleManualSave(): Promise<void> {
+    await this.saveFile();
+    this.toolbar?.setSaveButtonEnabled(false);
+  }
+
+  /**
+   * Save the current markdown content to file
+   */
+  private async saveFile(): Promise<void> {
+    if (!this.state.currentFilePath || !this.markdownViewer) return;
+
+    const markdown = this.markdownViewer.getCurrentMarkdown();
+
+    try {
+      const result = await window.electronAPI.file.write(
+        this.state.currentFilePath,
+        markdown
+      );
+
+      if (result.success) {
+        this.state.hasUnsavedChanges = false;
+        this.statusBar?.setModifiedTime(new Date());
+      } else {
+        this.toast?.error(`Save failed: ${result.error}`);
+      }
+    } catch (error) {
+      console.error('Failed to save file:', error);
+      this.toast?.error('Failed to save file');
+    }
   }
 
   /**

--- a/src/renderer/components/EditModeController.ts
+++ b/src/renderer/components/EditModeController.ts
@@ -1,0 +1,440 @@
+/**
+ * EditModeController - Manages edit mode with Notion-style slice rendering
+ *
+ * When edit mode is active, the markdown content is split into individual
+ * "slices" (blocks), each with hover states, a left-side handle for options,
+ * and inline editing via a textarea when clicked.
+ */
+import { MarkdownSlicer, type MarkdownSlice } from '../services/MarkdownSlicer';
+import type { PluginManager } from '@plugins/core/PluginManager';
+
+/**
+ * Callbacks for EditModeController events
+ */
+export interface EditModeCallbacks {
+  /** Called when the full markdown content changes (for auto-save) */
+  onContentChange?: (markdown: string) => void;
+  /** Called when a slice requests a context action */
+  onSliceAction?: (action: SliceAction, sliceIndex: number) => void;
+}
+
+/**
+ * Actions available from the slice handle menu
+ */
+export type SliceAction = 'delete' | 'duplicate' | 'move-up' | 'move-down' | 'add-above' | 'add-below';
+
+/**
+ * EditModeController class
+ */
+export class EditModeController {
+  private container: HTMLElement;
+  private pluginManager: PluginManager;
+  private slicer: MarkdownSlicer;
+  private slices: MarkdownSlice[] = [];
+  private rawMarkdown = '';
+  private callbacks: EditModeCallbacks = {};
+  private activeEditIndex: number | null = null;
+  private activeMenu: HTMLElement | null = null;
+  private sliceElements: Map<number, HTMLElement> = new Map();
+
+  constructor(container: HTMLElement, pluginManager: PluginManager) {
+    this.container = container;
+    this.pluginManager = pluginManager;
+    this.slicer = new MarkdownSlicer();
+
+    this.handleDocumentClick = this.handleDocumentClick.bind(this);
+  }
+
+  /**
+   * Set callbacks
+   */
+  setCallbacks(callbacks: EditModeCallbacks): void {
+    this.callbacks = { ...this.callbacks, ...callbacks };
+  }
+
+  /**
+   * Enter edit mode - render content as slices
+   */
+  async enter(markdown: string): Promise<void> {
+    this.rawMarkdown = markdown;
+    this.slices = this.slicer.slice(markdown);
+    await this.renderSlices();
+    document.addEventListener('click', this.handleDocumentClick);
+  }
+
+  /**
+   * Exit edit mode - commit any pending edits
+   */
+  exit(): string {
+    this.commitActiveEdit();
+    this.closeMenu();
+    document.removeEventListener('click', this.handleDocumentClick);
+    this.sliceElements.clear();
+    this.activeEditIndex = null;
+    return this.rawMarkdown;
+  }
+
+  /**
+   * Get the current markdown content
+   */
+  getMarkdown(): string {
+    return this.rawMarkdown;
+  }
+
+  /**
+   * Render all slices into the container
+   */
+  private async renderSlices(): Promise<void> {
+    this.container.innerHTML = '';
+    this.container.classList.add('edit-mode');
+    this.sliceElements.clear();
+
+    for (const slice of this.slices) {
+      const el = this.createSliceElement(slice);
+      this.container.appendChild(el);
+      this.sliceElements.set(slice.index, el);
+    }
+
+    // Run post-render for plugins (e.g., Mermaid diagrams)
+    await this.pluginManager.postRender(this.container);
+  }
+
+  /**
+   * Create a single slice DOM element
+   */
+  private createSliceElement(slice: MarkdownSlice): HTMLElement {
+    const wrapper = document.createElement('div');
+    wrapper.className = `slice slice-${slice.type}`;
+    wrapper.dataset.sliceIndex = String(slice.index);
+
+    // Left-side handle
+    const handle = document.createElement('div');
+    handle.className = 'slice-handle';
+    handle.innerHTML = `
+      <button class="slice-handle-btn" title="Drag to move / Click for options">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+          <circle cx="5.5" cy="3.5" r="1.5"/>
+          <circle cx="10.5" cy="3.5" r="1.5"/>
+          <circle cx="5.5" cy="8" r="1.5"/>
+          <circle cx="10.5" cy="8" r="1.5"/>
+          <circle cx="5.5" cy="12.5" r="1.5"/>
+          <circle cx="10.5" cy="12.5" r="1.5"/>
+        </svg>
+      </button>
+    `;
+    handle.querySelector('.slice-handle-btn')?.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this.toggleMenu(slice.index, handle);
+    });
+
+    // Content area
+    const content = document.createElement('div');
+    content.className = 'slice-content';
+
+    // Render the slice's markdown to HTML
+    const html = this.pluginManager.render(slice.raw);
+    content.innerHTML = html;
+
+    // Click to edit
+    content.addEventListener('click', (e) => {
+      // Don't enter edit if clicking a link
+      if ((e.target as HTMLElement).closest('a')) return;
+      e.stopPropagation();
+      this.startEdit(slice.index);
+    });
+
+    wrapper.appendChild(handle);
+    wrapper.appendChild(content);
+
+    return wrapper;
+  }
+
+  /**
+   * Start inline editing of a slice
+   */
+  private startEdit(sliceIndex: number): void {
+    // Commit any previous edit
+    this.commitActiveEdit();
+
+    const slice = this.slices.find(s => s.index === sliceIndex);
+    const el = this.sliceElements.get(sliceIndex);
+    if (!slice || !el) return;
+
+    this.activeEditIndex = sliceIndex;
+    el.classList.add('slice-editing');
+
+    const contentEl = el.querySelector('.slice-content');
+    if (!contentEl) return;
+
+    // Replace rendered HTML with textarea
+    const textarea = document.createElement('textarea');
+    textarea.className = 'slice-editor';
+    textarea.value = slice.raw;
+    textarea.spellcheck = false;
+
+    // Auto-resize
+    const resize = (): void => {
+      textarea.style.height = 'auto';
+      textarea.style.height = textarea.scrollHeight + 'px';
+    };
+
+    textarea.addEventListener('input', resize);
+
+    // Handle keyboard shortcuts
+    textarea.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        this.commitActiveEdit();
+      }
+    });
+
+    contentEl.innerHTML = '';
+    contentEl.appendChild(textarea);
+
+    // Focus and resize
+    textarea.focus();
+    resize();
+  }
+
+  /**
+   * Commit the active edit and re-render the slice
+   */
+  private async commitActiveEdit(): Promise<void> {
+    if (this.activeEditIndex === null) return;
+
+    const sliceIndex = this.activeEditIndex;
+    const el = this.sliceElements.get(sliceIndex);
+    if (!el) {
+      this.activeEditIndex = null;
+      return;
+    }
+
+    const textarea = el.querySelector<HTMLTextAreaElement>('.slice-editor');
+    if (!textarea) {
+      this.activeEditIndex = null;
+      return;
+    }
+
+    const newRaw = textarea.value;
+    const slice = this.slices.find(s => s.index === sliceIndex);
+
+    if (slice && newRaw !== slice.raw) {
+      // Update the slice and recalculate
+      const result = this.slicer.updateSlice(this.slices, sliceIndex, newRaw);
+      this.rawMarkdown = result.markdown;
+      this.slices = result.slices;
+
+      // Notify of content change
+      this.callbacks.onContentChange?.(this.rawMarkdown);
+    }
+
+    // Re-render just this slice's content
+    el.classList.remove('slice-editing');
+    const contentEl = el.querySelector('.slice-content');
+    if (contentEl && slice) {
+      const updatedSlice = this.slices.find(s => s.index === sliceIndex);
+      const html = this.pluginManager.render(updatedSlice?.raw ?? slice.raw);
+      contentEl.innerHTML = html;
+
+      // Re-attach click handler
+      contentEl.addEventListener('click', (e) => {
+        if ((e.target as HTMLElement).closest('a')) return;
+        e.stopPropagation();
+        this.startEdit(sliceIndex);
+      });
+
+      // Run post-render for this content
+      await this.pluginManager.postRender(contentEl as HTMLElement);
+    }
+
+    this.activeEditIndex = null;
+  }
+
+  /**
+   * Toggle the options menu for a slice handle
+   */
+  private toggleMenu(sliceIndex: number, handleEl: HTMLElement): void {
+    if (this.activeMenu) {
+      this.closeMenu();
+      return;
+    }
+
+    const menu = document.createElement('div');
+    menu.className = 'slice-menu';
+    menu.innerHTML = `
+      <button data-action="add-above" class="slice-menu-item">
+        <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M8 2a.5.5 0 0 1 .5.5v5h5a.5.5 0 0 1 0 1h-5v5a.5.5 0 0 1-1 0v-5h-5a.5.5 0 0 1 0-1h5v-5A.5.5 0 0 1 8 2z"/>
+        </svg>
+        Add block above
+      </button>
+      <button data-action="add-below" class="slice-menu-item">
+        <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M8 2a.5.5 0 0 1 .5.5v5h5a.5.5 0 0 1 0 1h-5v5a.5.5 0 0 1-1 0v-5h-5a.5.5 0 0 1 0-1h5v-5A.5.5 0 0 1 8 2z"/>
+        </svg>
+        Add block below
+      </button>
+      <div class="slice-menu-divider"></div>
+      <button data-action="duplicate" class="slice-menu-item">
+        <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1v-1z"/>
+          <path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h3zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3z"/>
+        </svg>
+        Duplicate
+      </button>
+      <button data-action="move-up" class="slice-menu-item">
+        <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+          <path fill-rule="evenodd" d="M7.646 4.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1-.708.708L8 5.707l-5.646 5.647a.5.5 0 0 1-.708-.708l6-6z"/>
+        </svg>
+        Move up
+      </button>
+      <button data-action="move-down" class="slice-menu-item">
+        <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+          <path fill-rule="evenodd" d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/>
+        </svg>
+        Move down
+      </button>
+      <div class="slice-menu-divider"></div>
+      <button data-action="delete" class="slice-menu-item slice-menu-item-danger">
+        <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"/>
+          <path fill-rule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H5.5l1-1h3l1 1H13a1 1 0 0 1 1 1v1z"/>
+        </svg>
+        Delete
+      </button>
+    `;
+
+    // Handle menu item clicks
+    menu.querySelectorAll('.slice-menu-item').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const action = (btn as HTMLElement).dataset.action as SliceAction;
+        this.closeMenu();
+        this.handleSliceAction(action, sliceIndex);
+      });
+    });
+
+    handleEl.appendChild(menu);
+    this.activeMenu = menu;
+  }
+
+  /**
+   * Close the active options menu
+   */
+  private closeMenu(): void {
+    if (this.activeMenu) {
+      this.activeMenu.remove();
+      this.activeMenu = null;
+    }
+  }
+
+  /**
+   * Handle document click to close menu and commit edits
+   */
+  private handleDocumentClick(e: MouseEvent): void {
+    const target = e.target as HTMLElement;
+
+    // Close menu if clicking outside
+    if (this.activeMenu && !this.activeMenu.contains(target)) {
+      this.closeMenu();
+    }
+
+    // Commit edit if clicking outside active slice
+    if (this.activeEditIndex !== null) {
+      const activeEl = this.sliceElements.get(this.activeEditIndex);
+      if (activeEl && !activeEl.contains(target)) {
+        void this.commitActiveEdit();
+      }
+    }
+  }
+
+  /**
+   * Handle slice actions from the context menu
+   */
+  private handleSliceAction(action: SliceAction, sliceIndex: number): void {
+    this.commitActiveEdit();
+
+    const idx = this.slices.findIndex(s => s.index === sliceIndex);
+    if (idx === -1) return;
+
+    switch (action) {
+      case 'delete':
+        this.slices.splice(idx, 1);
+        break;
+
+      case 'duplicate': {
+        const original = this.slices[idx];
+        const newSlice: MarkdownSlice = {
+          ...original,
+          index: Math.max(...this.slices.map(s => s.index)) + 1,
+        };
+        this.slices.splice(idx + 1, 0, newSlice);
+        break;
+      }
+
+      case 'move-up':
+        if (idx > 0) {
+          const [item] = this.slices.splice(idx, 1);
+          this.slices.splice(idx - 1, 0, item);
+        }
+        break;
+
+      case 'move-down':
+        if (idx < this.slices.length - 1) {
+          const [item] = this.slices.splice(idx, 1);
+          this.slices.splice(idx + 1, 0, item);
+        }
+        break;
+
+      case 'add-above': {
+        const newSlice: MarkdownSlice = {
+          index: Math.max(...this.slices.map(s => s.index)) + 1,
+          type: 'paragraph',
+          raw: '',
+          startLine: this.slices[idx].startLine,
+          endLine: this.slices[idx].startLine,
+        };
+        this.slices.splice(idx, 0, newSlice);
+        break;
+      }
+
+      case 'add-below': {
+        const newSlice: MarkdownSlice = {
+          index: Math.max(...this.slices.map(s => s.index)) + 1,
+          type: 'paragraph',
+          raw: '',
+          startLine: this.slices[idx].endLine,
+          endLine: this.slices[idx].endLine,
+        };
+        this.slices.splice(idx + 1, 0, newSlice);
+        break;
+      }
+    }
+
+    // Reassemble and re-render
+    this.rawMarkdown = this.slicer.reassemble(this.slices);
+    this.callbacks.onContentChange?.(this.rawMarkdown);
+
+    // Re-slice and render from scratch for structural changes
+    this.slices = this.slicer.slice(this.rawMarkdown);
+    void this.renderSlices().then(() => {
+      // Auto-focus new empty blocks
+      if (action === 'add-above' || action === 'add-below') {
+        const newIdx = action === 'add-above' ? idx : idx + 1;
+        if (this.slices[newIdx]) {
+          this.startEdit(this.slices[newIdx].index);
+        }
+      }
+    });
+  }
+}
+
+/**
+ * Factory function
+ */
+export function createEditModeController(
+  container: HTMLElement,
+  pluginManager: PluginManager
+): EditModeController {
+  return new EditModeController(container, pluginManager);
+}

--- a/src/renderer/components/EditModeController.ts
+++ b/src/renderer/components/EditModeController.ts
@@ -24,6 +24,11 @@ export interface EditModeCallbacks {
 export type SliceAction = 'delete' | 'duplicate' | 'move-up' | 'move-down' | 'add-above' | 'add-below';
 
 /**
+ * Block types a slice can be converted to
+ */
+export type BlockType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'paragraph' | 'bullet-list' | 'numbered-list' | 'blockquote' | 'code';
+
+/**
  * EditModeController class
  */
 export class EditModeController {
@@ -254,9 +259,65 @@ export class EditModeController {
       return;
     }
 
+    const slice = this.slices.find(s => s.index === sliceIndex);
+    const currentBlockType = slice ? this.detectBlockType(slice.raw) : 'paragraph';
+
     const menu = document.createElement('div');
     menu.className = 'slice-menu';
-    menu.innerHTML = `
+
+    // "Turn into" submenu trigger
+    const turnIntoItem = document.createElement('div');
+    turnIntoItem.className = 'slice-menu-item slice-menu-submenu-trigger';
+    turnIntoItem.innerHTML = `
+      <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+        <path d="M1 2.828c.885-.37 2.154-.769 3.388-.893 1.33-.134 2.458.063 3.112.752v9.746c-.935-.53-2.12-.603-3.213-.493-1.18.12-2.37.461-3.287.811V2.828zm7.5-.141c.654-.689 1.782-.886 3.112-.752 1.234.124 2.503.523 3.388.893v9.923c-.918-.35-2.107-.692-3.287-.81-1.094-.111-2.278-.039-3.213.492V2.687zM8 1.783C7.015.936 5.587.81 4.287.94c-1.514.153-3.042.672-3.994 1.105A.5.5 0 0 0 0 2.5v11a.5.5 0 0 0 .707.455c.882-.4 2.303-.881 3.68-1.02 1.409-.142 2.59.087 3.223.877a.5.5 0 0 0 .78 0c.633-.79 1.814-1.019 3.222-.877 1.378.139 2.8.62 3.681 1.02A.5.5 0 0 0 16 13.5v-11a.5.5 0 0 0-.293-.455c-.952-.433-2.48-.952-3.994-1.105C10.413.809 8.985.936 8 1.783z"/>
+      </svg>
+      Turn into
+      <svg class="slice-menu-chevron" width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
+        <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"/>
+      </svg>
+    `;
+
+    // Build submenu
+    const submenu = document.createElement('div');
+    submenu.className = 'slice-submenu';
+
+    const blockTypes: { type: BlockType; label: string; shortLabel: string }[] = [
+      { type: 'paragraph', label: 'Text', shortLabel: 'Aa' },
+      { type: 'h1', label: 'Heading 1', shortLabel: 'H1' },
+      { type: 'h2', label: 'Heading 2', shortLabel: 'H2' },
+      { type: 'h3', label: 'Heading 3', shortLabel: 'H3' },
+      { type: 'h4', label: 'Heading 4', shortLabel: 'H4' },
+      { type: 'h5', label: 'Heading 5', shortLabel: 'H5' },
+      { type: 'h6', label: 'Heading 6', shortLabel: 'H6' },
+      { type: 'bullet-list', label: 'Bullet list', shortLabel: '•' },
+      { type: 'numbered-list', label: 'Numbered list', shortLabel: '1.' },
+      { type: 'blockquote', label: 'Quote', shortLabel: '"' },
+      { type: 'code', label: 'Code block', shortLabel: '</>' },
+    ];
+
+    for (const bt of blockTypes) {
+      const btn = document.createElement('button');
+      btn.className = 'slice-menu-item';
+      if (bt.type === currentBlockType) {
+        btn.classList.add('slice-menu-item-active');
+      }
+      btn.dataset.blockType = bt.type;
+      btn.innerHTML = `<span class="slice-block-type-badge">${bt.shortLabel}</span> ${bt.label}`;
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        this.closeMenu();
+        this.convertSlice(sliceIndex, bt.type);
+      });
+      submenu.appendChild(btn);
+    }
+
+    turnIntoItem.appendChild(submenu);
+    menu.appendChild(turnIntoItem);
+
+    // Rest of the menu items
+    menu.insertAdjacentHTML('beforeend', `
+      <div class="slice-menu-divider"></div>
       <button data-action="add-above" class="slice-menu-item">
         <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
           <path d="M8 2a.5.5 0 0 1 .5.5v5h5a.5.5 0 0 1 0 1h-5v5a.5.5 0 0 1-1 0v-5h-5a.5.5 0 0 1 0-1h5v-5A.5.5 0 0 1 8 2z"/>
@@ -297,10 +358,10 @@ export class EditModeController {
         </svg>
         Delete
       </button>
-    `;
+    `);
 
-    // Handle menu item clicks
-    menu.querySelectorAll('.slice-menu-item').forEach(btn => {
+    // Handle action menu item clicks
+    menu.querySelectorAll('.slice-menu-item[data-action]').forEach(btn => {
       btn.addEventListener('click', (e) => {
         e.stopPropagation();
         const action = (btn as HTMLElement).dataset.action as SliceAction;
@@ -341,6 +402,106 @@ export class EditModeController {
         this.commitActiveEdit();
       }
     }
+  }
+
+  /**
+   * Detect the current block type from raw markdown
+   */
+  private detectBlockType(raw: string): BlockType {
+    const trimmed = raw.trimStart();
+    if (trimmed.startsWith('######')) return 'h6';
+    if (trimmed.startsWith('#####')) return 'h5';
+    if (trimmed.startsWith('####')) return 'h4';
+    if (trimmed.startsWith('###')) return 'h3';
+    if (trimmed.startsWith('##')) return 'h2';
+    if (trimmed.startsWith('# ')) return 'h1';
+    if (trimmed.startsWith('```')) return 'code';
+    if (trimmed.startsWith('>')) return 'blockquote';
+    if (/^\d+\.\s/.test(trimmed)) return 'numbered-list';
+    if (/^[-*+]\s/.test(trimmed)) return 'bullet-list';
+    return 'paragraph';
+  }
+
+  /**
+   * Strip existing block prefix from raw markdown to get plain text content.
+   * For multi-line blocks (code, blockquote), handles each line appropriately.
+   */
+  private stripBlockPrefix(raw: string): string {
+    const trimmed = raw.trimStart();
+
+    // Code block: unwrap from fences
+    if (trimmed.startsWith('```')) {
+      const lines = trimmed.split('\n');
+      // Remove opening fence (possibly with language) and closing fence
+      const inner = lines.slice(1, lines[lines.length - 1]?.trim() === '```' ? -1 : undefined);
+      return inner.join('\n');
+    }
+
+    // Blockquote: strip leading > from each line
+    if (trimmed.startsWith('>')) {
+      return trimmed.split('\n').map(line => line.replace(/^>\s?/, '')).join('\n');
+    }
+
+    // Heading
+    const headingMatch = trimmed.match(/^#{1,6}\s+(.*)/s);
+    if (headingMatch) return headingMatch[1];
+
+    // List item
+    const listMatch = trimmed.match(/^(?:[-*+]|\d+\.)\s+(.*)/s);
+    if (listMatch) return listMatch[1];
+
+    return raw;
+  }
+
+  /**
+   * Apply a block type prefix to plain text content
+   */
+  private applyBlockPrefix(content: string, blockType: BlockType): string {
+    const text = content.trim();
+    switch (blockType) {
+      case 'h1': return `# ${text}`;
+      case 'h2': return `## ${text}`;
+      case 'h3': return `### ${text}`;
+      case 'h4': return `#### ${text}`;
+      case 'h5': return `##### ${text}`;
+      case 'h6': return `###### ${text}`;
+      case 'bullet-list': return `- ${text}`;
+      case 'numbered-list': return `1. ${text}`;
+      case 'blockquote':
+        return text.split('\n').map(line => `> ${line}`).join('\n');
+      case 'code':
+        return `\`\`\`\n${text}\n\`\`\``;
+      case 'paragraph':
+      default:
+        return text;
+    }
+  }
+
+  /**
+   * Convert a slice to a different block type
+   */
+  private convertSlice(sliceIndex: number, targetType: BlockType): void {
+    this.commitActiveEdit();
+
+    const slice = this.slices.find(s => s.index === sliceIndex);
+    if (!slice) return;
+
+    const currentType = this.detectBlockType(slice.raw);
+    if (currentType === targetType) return;
+
+    // Strip current prefix, apply new one
+    const plainContent = this.stripBlockPrefix(slice.raw);
+    const newRaw = this.applyBlockPrefix(plainContent, targetType);
+
+    // Update slice via slicer
+    const result = this.slicer.updateSlice(this.slices, sliceIndex, newRaw);
+    this.rawMarkdown = result.markdown;
+    this.slices = result.slices;
+    this.callbacks.onContentChange?.(this.rawMarkdown);
+
+    // Re-slice and re-render to ensure correct structure
+    this.slices = this.slicer.slice(this.rawMarkdown);
+    void this.renderSlices();
   }
 
   /**

--- a/src/renderer/components/EditModeController.ts
+++ b/src/renderer/components/EditModeController.ts
@@ -46,8 +46,6 @@ export class EditModeController {
     this.container = container;
     this.pluginManager = pluginManager;
     this.slicer = new MarkdownSlicer();
-
-    this.handleDocumentClick = this.handleDocumentClick.bind(this);
   }
 
   /**
@@ -387,7 +385,7 @@ export class EditModeController {
   /**
    * Handle document click to close menu and commit edits
    */
-  private handleDocumentClick(e: MouseEvent): void {
+  private handleDocumentClick = (e: MouseEvent): void => {
     const target = e.target as HTMLElement;
 
     // Close menu if clicking outside

--- a/src/renderer/components/EditModeController.ts
+++ b/src/renderer/components/EditModeController.ts
@@ -444,11 +444,11 @@ export class EditModeController {
 
     // Heading
     const headingMatch = trimmed.match(/^#{1,6}\s+(.*)/s);
-    if (headingMatch) return headingMatch[1];
+    if (headingMatch?.[1] != null) return headingMatch[1];
 
     // List item
     const listMatch = trimmed.match(/^(?:[-*+]|\d+\.)\s+(.*)/s);
-    if (listMatch) return listMatch[1];
+    if (listMatch?.[1] != null) return listMatch[1];
 
     return raw;
   }
@@ -519,7 +519,7 @@ export class EditModeController {
         break;
 
       case 'duplicate': {
-        const original = this.slices[idx];
+        const original = this.slices[idx]!;
         const newSlice: MarkdownSlice = {
           ...original,
           index: Math.max(...this.slices.map(s => s.index)) + 1,
@@ -531,36 +531,38 @@ export class EditModeController {
       case 'move-up':
         if (idx > 0) {
           const [item] = this.slices.splice(idx, 1);
-          this.slices.splice(idx - 1, 0, item);
+          this.slices.splice(idx - 1, 0, item!);
         }
         break;
 
       case 'move-down':
         if (idx < this.slices.length - 1) {
           const [item] = this.slices.splice(idx, 1);
-          this.slices.splice(idx + 1, 0, item);
+          this.slices.splice(idx + 1, 0, item!);
         }
         break;
 
       case 'add-above': {
+        const ref = this.slices[idx]!;
         const newSlice: MarkdownSlice = {
           index: Math.max(...this.slices.map(s => s.index)) + 1,
           type: 'paragraph',
           raw: '',
-          startLine: this.slices[idx].startLine,
-          endLine: this.slices[idx].startLine,
+          startLine: ref.startLine,
+          endLine: ref.startLine,
         };
         this.slices.splice(idx, 0, newSlice);
         break;
       }
 
       case 'add-below': {
+        const ref = this.slices[idx]!;
         const newSlice: MarkdownSlice = {
           index: Math.max(...this.slices.map(s => s.index)) + 1,
           type: 'paragraph',
           raw: '',
-          startLine: this.slices[idx].endLine,
-          endLine: this.slices[idx].endLine,
+          startLine: ref.endLine,
+          endLine: ref.endLine,
         };
         this.slices.splice(idx + 1, 0, newSlice);
         break;
@@ -577,8 +579,9 @@ export class EditModeController {
       // Auto-focus new empty blocks
       if (action === 'add-above' || action === 'add-below') {
         const newIdx = action === 'add-above' ? idx : idx + 1;
-        if (this.slices[newIdx]) {
-          this.startEdit(this.slices[newIdx].index);
+        const newSlice = this.slices[newIdx];
+        if (newSlice) {
+          this.startEdit(newSlice.index);
         }
       }
     });

--- a/src/renderer/components/EditModeController.ts
+++ b/src/renderer/components/EditModeController.ts
@@ -199,21 +199,18 @@ export class EditModeController {
   /**
    * Commit the active edit and re-render the slice
    */
-  private async commitActiveEdit(): Promise<void> {
+  private commitActiveEdit(): void {
     if (this.activeEditIndex === null) return;
 
     const sliceIndex = this.activeEditIndex;
+    // Clear immediately to prevent race conditions with async postRender
+    this.activeEditIndex = null;
+
     const el = this.sliceElements.get(sliceIndex);
-    if (!el) {
-      this.activeEditIndex = null;
-      return;
-    }
+    if (!el) return;
 
     const textarea = el.querySelector<HTMLTextAreaElement>('.slice-editor');
-    if (!textarea) {
-      this.activeEditIndex = null;
-      return;
-    }
+    if (!textarea) return;
 
     const newRaw = textarea.value;
     const slice = this.slices.find(s => s.index === sliceIndex);
@@ -243,11 +240,9 @@ export class EditModeController {
         this.startEdit(sliceIndex);
       });
 
-      // Run post-render for this content
-      await this.pluginManager.postRender(contentEl as HTMLElement);
+      // Run post-render asynchronously (non-blocking)
+      void this.pluginManager.postRender(contentEl as HTMLElement);
     }
-
-    this.activeEditIndex = null;
   }
 
   /**
@@ -343,7 +338,7 @@ export class EditModeController {
     if (this.activeEditIndex !== null) {
       const activeEl = this.sliceElements.get(this.activeEditIndex);
       if (activeEl && !activeEl.contains(target)) {
-        void this.commitActiveEdit();
+        this.commitActiveEdit();
       }
     }
   }

--- a/src/renderer/components/MarkdownViewer.ts
+++ b/src/renderer/components/MarkdownViewer.ts
@@ -12,6 +12,9 @@ import {
 import { BUILTIN_PLUGINS } from '@shared/constants';
 import { Toast } from './Toast';
 
+import { EditModeController, createEditModeController } from './EditModeController';
+import type { EditModeCallbacks } from './EditModeController';
+
 import type {
   MarkdownPlugin,
   ContextMenuData,
@@ -42,6 +45,8 @@ export class MarkdownViewer {
   private initialized = false;
   private highlightedElement: HTMLElement | null = null;
   private toast: Toast;
+  private editModeController: EditModeController | null = null;
+  private isEditMode = false;
 
   constructor(container: HTMLElement) {
     this.container = container;
@@ -220,6 +225,56 @@ export class MarkdownViewer {
     preferencesMap: Record<string, unknown>
   ): void {
     this.pluginManager.notifyAllPluginsPreferencesChange(preferencesMap);
+  }
+
+  /**
+   * Enter edit mode - switch to slice-based rendering
+   */
+  async enterEditMode(callbacks?: EditModeCallbacks): Promise<void> {
+    if (this.isEditMode || !this.state.content) return;
+
+    this.isEditMode = true;
+    this.editModeController = createEditModeController(
+      this.container,
+      this.pluginManager
+    );
+    if (callbacks) {
+      this.editModeController.setCallbacks(callbacks);
+    }
+    await this.editModeController.enter(this.state.content);
+  }
+
+  /**
+   * Exit edit mode - return to normal rendering
+   */
+  async exitEditMode(): Promise<void> {
+    if (!this.isEditMode || !this.editModeController) return;
+
+    const markdown = this.editModeController.exit();
+    this.isEditMode = false;
+    this.editModeController = null;
+    this.container.classList.remove('edit-mode');
+
+    // Update state and re-render normally
+    this.state.content = markdown;
+    await this.render(markdown, this.state.filePath ?? undefined);
+  }
+
+  /**
+   * Check if in edit mode
+   */
+  getEditMode(): boolean {
+    return this.isEditMode;
+  }
+
+  /**
+   * Get the current markdown (possibly modified in edit mode)
+   */
+  getCurrentMarkdown(): string {
+    if (this.isEditMode && this.editModeController) {
+      return this.editModeController.getMarkdown();
+    }
+    return this.state.content;
   }
 
   /**

--- a/src/renderer/components/Toolbar.ts
+++ b/src/renderer/components/Toolbar.ts
@@ -10,8 +10,9 @@ export interface ToolbarCallbacks {
   onOpenFile?: () => void;
   onToggleTheme?: () => void;
   onOpenPreferences?: () => void;
-  onToggleEditMode?: () => void;
   onSave?: () => void;
+  onEnterEditMode?: () => void;
+  onCancelEdit?: () => void;
 }
 
 /**
@@ -23,11 +24,18 @@ export class Toolbar {
   private preferencesBtn: HTMLButtonElement | null = null;
   private themeToggleBtn: HTMLButtonElement | null = null;
   private editModeBtn: HTMLButtonElement | null = null;
-  private saveBtn: HTMLButtonElement | null = null;
+  private editSaveArrow: HTMLButtonElement | null = null;
+  private editSaveGroup: HTMLElement | null = null;
+  private editSaveMenu: HTMLElement | null = null;
+  private editSaveLabel: HTMLElement | null = null;
+  private editIcon: HTMLElement | null = null;
+  private saveIcon: HTMLElement | null = null;
+  private cancelEditBtn: HTMLButtonElement | null = null;
   private fileNameElement: HTMLElement | null = null;
   private themeIconLight: HTMLElement | null = null;
   private themeIconDark: HTMLElement | null = null;
   private callbacks: ToolbarCallbacks = {};
+  private isEditMode = false;
 
   constructor(element: HTMLElement) {
     this.element = element;
@@ -43,7 +51,13 @@ export class Toolbar {
     this.preferencesBtn = this.element.querySelector('#preferences-btn');
     this.themeToggleBtn = this.element.querySelector('#theme-toggle-btn');
     this.editModeBtn = this.element.querySelector('#edit-mode-btn');
-    this.saveBtn = this.element.querySelector('#save-btn');
+    this.editSaveArrow = this.element.querySelector('#edit-save-arrow');
+    this.editSaveGroup = this.element.querySelector('#edit-save-group');
+    this.editSaveMenu = this.element.querySelector('#edit-save-menu');
+    this.editSaveLabel = this.element.querySelector('#edit-save-label');
+    this.editIcon = this.element.querySelector('#edit-icon');
+    this.saveIcon = this.element.querySelector('#save-icon');
+    this.cancelEditBtn = this.element.querySelector('#cancel-edit-btn');
     this.fileNameElement = this.element.querySelector('#file-name');
     this.themeIconLight = this.element.querySelector('#theme-icon-light');
     this.themeIconDark = this.element.querySelector('#theme-icon-dark');
@@ -65,12 +79,31 @@ export class Toolbar {
       this.callbacks.onToggleTheme?.();
     });
 
+    // Main edit/save button - action depends on mode
     this.editModeBtn?.addEventListener('click', () => {
-      this.callbacks.onToggleEditMode?.();
+      if (this.isEditMode) {
+        this.callbacks.onSave?.();
+      } else {
+        this.callbacks.onEnterEditMode?.();
+      }
     });
 
-    this.saveBtn?.addEventListener('click', () => {
-      this.callbacks.onSave?.();
+    // Arrow button toggles dropdown
+    this.editSaveArrow?.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this.toggleEditSaveMenu();
+    });
+
+    // Cancel button in dropdown
+    this.cancelEditBtn?.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this.closeEditSaveMenu();
+      this.callbacks.onCancelEdit?.();
+    });
+
+    // Close dropdown when clicking outside
+    document.addEventListener('click', () => {
+      this.closeEditSaveMenu();
     });
   }
 
@@ -105,49 +138,62 @@ export class Toolbar {
     const isDark = theme === 'dark';
 
     if (this.themeIconLight && this.themeIconDark) {
-      // Show sun icon in dark mode (to switch to light)
-      // Show moon icon in light mode (to switch to dark)
       this.themeIconLight.style.display = isDark ? '' : 'none';
       this.themeIconDark.style.display = isDark ? 'none' : '';
     }
 
-    // Update button title
     if (this.themeToggleBtn) {
       this.themeToggleBtn.title = `Switch to ${isDark ? 'light' : 'dark'} theme`;
     }
   }
 
   /**
-   * Update the edit mode toggle button state
+   * Switch the edit/save button between Edit and Save states
    */
   setEditMode(isActive: boolean): void {
-    if (this.editModeBtn) {
-      if (isActive) {
-        this.editModeBtn.classList.add('toolbar-btn-active');
-        this.editModeBtn.title = 'Exit edit mode';
-      } else {
-        this.editModeBtn.classList.remove('toolbar-btn-active');
-        this.editModeBtn.title = 'Enter edit mode';
-      }
+    this.isEditMode = isActive;
+
+    if (isActive) {
+      // Transform into Save button with dropdown arrow
+      this.editModeBtn?.classList.add('toolbar-btn-active');
+      this.editSaveGroup?.classList.add('is-editing');
+      this.editSaveArrow?.classList.remove('hidden');
+      if (this.editSaveLabel) this.editSaveLabel.textContent = 'Save';
+      if (this.editModeBtn) this.editModeBtn.title = 'Save (Cmd+S)';
+      this.editIcon?.classList.add('hidden');
+      this.saveIcon?.classList.remove('hidden');
+    } else {
+      // Revert to Edit button (no dropdown)
+      this.editModeBtn?.classList.remove('toolbar-btn-active');
+      this.editSaveGroup?.classList.remove('is-editing');
+      this.editSaveArrow?.classList.add('hidden');
+      this.closeEditSaveMenu();
+      if (this.editSaveLabel) this.editSaveLabel.textContent = 'Edit';
+      if (this.editModeBtn) this.editModeBtn.title = 'Enter edit mode';
+      this.editIcon?.classList.remove('hidden');
+      this.saveIcon?.classList.add('hidden');
     }
   }
 
   /**
-   * Show or hide the save button (visible when auto-save is off in edit mode)
+   * Toggle the dropdown menu on the save button
    */
-  setSaveButtonVisible(visible: boolean): void {
-    if (this.saveBtn) {
-      this.saveBtn.classList.toggle('hidden', !visible);
+  private toggleEditSaveMenu(): void {
+    const isOpen = !this.editSaveMenu?.classList.contains('hidden');
+    if (isOpen) {
+      this.closeEditSaveMenu();
+    } else {
+      this.editSaveMenu?.classList.remove('hidden');
+      this.editSaveGroup?.classList.add('is-open');
     }
   }
 
   /**
-   * Set the save button enabled state
+   * Close the dropdown menu
    */
-  setSaveButtonEnabled(enabled: boolean): void {
-    if (this.saveBtn) {
-      this.saveBtn.disabled = !enabled;
-    }
+  private closeEditSaveMenu(): void {
+    this.editSaveMenu?.classList.add('hidden');
+    this.editSaveGroup?.classList.remove('is-open');
   }
 
   /**

--- a/src/renderer/components/Toolbar.ts
+++ b/src/renderer/components/Toolbar.ts
@@ -10,6 +10,8 @@ export interface ToolbarCallbacks {
   onOpenFile?: () => void;
   onToggleTheme?: () => void;
   onOpenPreferences?: () => void;
+  onToggleEditMode?: () => void;
+  onSave?: () => void;
 }
 
 /**
@@ -20,6 +22,8 @@ export class Toolbar {
   private openFileBtn: HTMLButtonElement | null = null;
   private preferencesBtn: HTMLButtonElement | null = null;
   private themeToggleBtn: HTMLButtonElement | null = null;
+  private editModeBtn: HTMLButtonElement | null = null;
+  private saveBtn: HTMLButtonElement | null = null;
   private fileNameElement: HTMLElement | null = null;
   private themeIconLight: HTMLElement | null = null;
   private themeIconDark: HTMLElement | null = null;
@@ -38,6 +42,8 @@ export class Toolbar {
     this.openFileBtn = this.element.querySelector('#open-file-btn');
     this.preferencesBtn = this.element.querySelector('#preferences-btn');
     this.themeToggleBtn = this.element.querySelector('#theme-toggle-btn');
+    this.editModeBtn = this.element.querySelector('#edit-mode-btn');
+    this.saveBtn = this.element.querySelector('#save-btn');
     this.fileNameElement = this.element.querySelector('#file-name');
     this.themeIconLight = this.element.querySelector('#theme-icon-light');
     this.themeIconDark = this.element.querySelector('#theme-icon-dark');
@@ -57,6 +63,14 @@ export class Toolbar {
 
     this.themeToggleBtn?.addEventListener('click', () => {
       this.callbacks.onToggleTheme?.();
+    });
+
+    this.editModeBtn?.addEventListener('click', () => {
+      this.callbacks.onToggleEditMode?.();
+    });
+
+    this.saveBtn?.addEventListener('click', () => {
+      this.callbacks.onSave?.();
     });
   }
 
@@ -100,6 +114,39 @@ export class Toolbar {
     // Update button title
     if (this.themeToggleBtn) {
       this.themeToggleBtn.title = `Switch to ${isDark ? 'light' : 'dark'} theme`;
+    }
+  }
+
+  /**
+   * Update the edit mode toggle button state
+   */
+  setEditMode(isActive: boolean): void {
+    if (this.editModeBtn) {
+      if (isActive) {
+        this.editModeBtn.classList.add('toolbar-btn-active');
+        this.editModeBtn.title = 'Exit edit mode';
+      } else {
+        this.editModeBtn.classList.remove('toolbar-btn-active');
+        this.editModeBtn.title = 'Enter edit mode';
+      }
+    }
+  }
+
+  /**
+   * Show or hide the save button (visible when auto-save is off in edit mode)
+   */
+  setSaveButtonVisible(visible: boolean): void {
+    if (this.saveBtn) {
+      this.saveBtn.classList.toggle('hidden', !visible);
+    }
+  }
+
+  /**
+   * Set the save button enabled state
+   */
+  setSaveButtonEnabled(enabled: boolean): void {
+    if (this.saveBtn) {
+      this.saveBtn.disabled = !enabled;
     }
   }
 

--- a/src/renderer/components/index.ts
+++ b/src/renderer/components/index.ts
@@ -112,3 +112,12 @@ export {
   createRecentFilesDropdown,
   type RecentFilesDropdownCallbacks,
 } from './RecentFilesDropdown';
+
+// EditModeController
+export {
+  EditModeController,
+  createEditModeController,
+  type EditModeCallbacks,
+  type SliceAction,
+  type BlockType,
+} from './EditModeController';

--- a/src/renderer/services/MarkdownSlicer.ts
+++ b/src/renderer/services/MarkdownSlicer.ts
@@ -61,7 +61,7 @@ export class MarkdownSlicer {
 
     let i = 0;
     while (i < tokens.length) {
-      const token = tokens[i];
+      const token = tokens[i]!;
 
       // Handle list blocks: split into individual list items
       if (token.type === 'bullet_list_open' || token.type === 'ordered_list_open') {
@@ -73,7 +73,7 @@ export class MarkdownSlicer {
         let depth = 0;
 
         while (i < tokens.length) {
-          const t = tokens[i];
+          const t = tokens[i]!;
 
           if (t.type === closeType && depth === 0) {
             i++; // skip list_close
@@ -95,12 +95,13 @@ export class MarkdownSlicer {
             let itemDepth = 1;
             i++;
             while (i < tokens.length && itemDepth > 0) {
-              if (tokens[i].type === 'list_item_open') itemDepth++;
-              if (tokens[i].type === 'list_item_close') itemDepth--;
+              if (tokens[i]!.type === 'list_item_open') itemDepth++;
+              if (tokens[i]!.type === 'list_item_close') itemDepth--;
               if (itemDepth > 0) i++;
             }
             // tokens[i] is now list_item_close
-            const endLine = tokens[i].map ? tokens[i].map[1] : startLine + 1;
+            const closeToken = tokens[i]!;
+            const endLine = closeToken.map ? closeToken.map[1] : startLine + 1;
             const raw = this.extractLines(lines, startLine, endLine);
 
             slices.push({
@@ -132,8 +133,8 @@ export class MarkdownSlicer {
           let depth = 1;
           let j = i + 1;
           while (j < tokens.length && depth > 0) {
-            if (tokens[j].type === token.type) depth++;
-            if (tokens[j].type === closeType) depth--;
+            if (tokens[j]!.type === token.type) depth++;
+            if (tokens[j]!.type === closeType) depth--;
             j++;
           }
           // j-1 is the closing token

--- a/src/renderer/services/MarkdownSlicer.ts
+++ b/src/renderer/services/MarkdownSlicer.ts
@@ -1,0 +1,296 @@
+/**
+ * MarkdownSlicer - Parses markdown into individual slices (blocks)
+ *
+ * Each slice represents a discrete content block similar to Notion's block model:
+ * headings, paragraphs, list items, code blocks, blockquotes, tables, etc.
+ */
+import MarkdownIt from 'markdown-it';
+
+/**
+ * Type of markdown slice
+ */
+export type SliceType =
+  | 'heading'
+  | 'paragraph'
+  | 'list-item'
+  | 'code'
+  | 'blockquote'
+  | 'table'
+  | 'hr'
+  | 'html'
+  | 'unknown';
+
+/**
+ * A single markdown slice representing a content block
+ */
+export interface MarkdownSlice {
+  /** Unique index of this slice */
+  index: number;
+  /** Type of content block */
+  type: SliceType;
+  /** Raw markdown source for this slice */
+  raw: string;
+  /** Starting line in the original markdown (0-based) */
+  startLine: number;
+  /** Ending line in the original markdown (exclusive, 0-based) */
+  endLine: number;
+}
+
+/**
+ * MarkdownSlicer class
+ */
+export class MarkdownSlicer {
+  private md: MarkdownIt;
+
+  constructor() {
+    this.md = new MarkdownIt({
+      html: true,
+      linkify: true,
+      typographer: true,
+    });
+  }
+
+  /**
+   * Parse markdown text into slices
+   */
+  slice(markdown: string): MarkdownSlice[] {
+    const lines = markdown.split('\n');
+    const tokens = this.md.parse(markdown, {});
+    const slices: MarkdownSlice[] = [];
+    let sliceIndex = 0;
+
+    let i = 0;
+    while (i < tokens.length) {
+      const token = tokens[i];
+
+      // Handle list blocks: split into individual list items
+      if (token.type === 'bullet_list_open' || token.type === 'ordered_list_open') {
+        const closeType = token.type === 'bullet_list_open'
+          ? 'bullet_list_close'
+          : 'ordered_list_close';
+
+        i++; // skip list_open
+        let depth = 0;
+
+        while (i < tokens.length) {
+          const t = tokens[i];
+
+          if (t.type === closeType && depth === 0) {
+            i++; // skip list_close
+            break;
+          }
+
+          // Track nested list depth
+          if (t.type === 'bullet_list_open' || t.type === 'ordered_list_open') {
+            depth++;
+          }
+          if (t.type === 'bullet_list_close' || t.type === 'ordered_list_close') {
+            depth--;
+          }
+
+          // Only extract top-level list items
+          if (t.type === 'list_item_open' && depth === 0) {
+            const startLine = t.map ? t.map[0] : -1;
+            // Find matching list_item_close
+            let itemDepth = 1;
+            i++;
+            while (i < tokens.length && itemDepth > 0) {
+              if (tokens[i].type === 'list_item_open') itemDepth++;
+              if (tokens[i].type === 'list_item_close') itemDepth--;
+              if (itemDepth > 0) i++;
+            }
+            // tokens[i] is now list_item_close
+            const endLine = tokens[i].map ? tokens[i].map[1] : startLine + 1;
+            const raw = this.extractLines(lines, startLine, endLine);
+
+            slices.push({
+              index: sliceIndex++,
+              type: 'list-item',
+              raw,
+              startLine,
+              endLine,
+            });
+            i++; // skip list_item_close
+          } else {
+            i++;
+          }
+        }
+        continue;
+      }
+
+      // Handle block tokens with source maps
+      if (token.map && token.nesting !== -1) {
+        const type = this.getSliceType(token.type);
+        const startLine = token.map[0];
+
+        // Find the closing token for paired elements
+        let endLine = token.map[1];
+
+        if (token.nesting === 1) {
+          // Opening tag - find its closing pair
+          const closeType = token.type.replace('_open', '_close');
+          let depth = 1;
+          let j = i + 1;
+          while (j < tokens.length && depth > 0) {
+            if (tokens[j].type === token.type) depth++;
+            if (tokens[j].type === closeType) depth--;
+            j++;
+          }
+          // j-1 is the closing token
+          const closeToken = tokens[j - 1];
+          if (closeToken?.map) {
+            endLine = closeToken.map[1];
+          }
+          // Skip to after the closing token
+          const raw = this.extractLines(lines, startLine, endLine);
+          slices.push({
+            index: sliceIndex++,
+            type,
+            raw,
+            startLine,
+            endLine,
+          });
+          i = j;
+          continue;
+        }
+
+        // Self-closing tokens (fence, hr, html_block)
+        const raw = this.extractLines(lines, startLine, endLine);
+        slices.push({
+          index: sliceIndex++,
+          type,
+          raw,
+          startLine,
+          endLine,
+        });
+      }
+
+      i++;
+    }
+
+    // Sort by line number and fill gaps with raw content
+    slices.sort((a, b) => a.startLine - b.startLine);
+
+    return this.fillGaps(slices, lines);
+  }
+
+  /**
+   * Map markdown-it token types to our slice types
+   */
+  private getSliceType(tokenType: string): SliceType {
+    if (tokenType.startsWith('heading')) return 'heading';
+    if (tokenType === 'paragraph_open' || tokenType === 'paragraph') return 'paragraph';
+    if (tokenType === 'fence' || tokenType === 'code_block') return 'code';
+    if (tokenType.startsWith('blockquote')) return 'blockquote';
+    if (tokenType.startsWith('table')) return 'table';
+    if (tokenType === 'hr') return 'hr';
+    if (tokenType === 'html_block') return 'html';
+    return 'unknown';
+  }
+
+  /**
+   * Extract lines from the source
+   */
+  private extractLines(lines: string[], start: number, end: number): string {
+    return lines.slice(start, end).join('\n');
+  }
+
+  /**
+   * Fill in any gaps between slices (empty lines, content the parser didn't map)
+   */
+  private fillGaps(slices: MarkdownSlice[], lines: string[]): MarkdownSlice[] {
+    if (slices.length === 0 && lines.length > 0) {
+      // No slices parsed - return entire content as one slice
+      const raw = lines.join('\n');
+      if (raw.trim()) {
+        return [{
+          index: 0,
+          type: 'paragraph',
+          raw,
+          startLine: 0,
+          endLine: lines.length,
+        }];
+      }
+      return [];
+    }
+
+    const result: MarkdownSlice[] = [];
+    let currentLine = 0;
+    let idx = 0;
+
+    for (const slice of slices) {
+      // Add gap content if there is significant content between slices
+      if (slice.startLine > currentLine) {
+        const gapRaw = this.extractLines(lines, currentLine, slice.startLine);
+        if (gapRaw.trim()) {
+          result.push({
+            index: idx++,
+            type: 'paragraph',
+            raw: gapRaw,
+            startLine: currentLine,
+            endLine: slice.startLine,
+          });
+        }
+      }
+      result.push({ ...slice, index: idx++ });
+      currentLine = Math.max(currentLine, slice.endLine);
+    }
+
+    // Handle trailing content
+    if (currentLine < lines.length) {
+      const trailingRaw = this.extractLines(lines, currentLine, lines.length);
+      if (trailingRaw.trim()) {
+        result.push({
+          index: idx++,
+          type: 'paragraph',
+          raw: trailingRaw,
+          startLine: currentLine,
+          endLine: lines.length,
+        });
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Reassemble full markdown from slices
+   */
+  reassemble(slices: MarkdownSlice[]): string {
+    const sorted = [...slices].sort((a, b) => a.startLine - b.startLine);
+    return sorted.map(s => s.raw).join('\n');
+  }
+
+  /**
+   * Update a single slice's raw content and return the full reassembled markdown.
+   * Recalculates line numbers for all subsequent slices.
+   */
+  updateSlice(slices: MarkdownSlice[], sliceIndex: number, newRaw: string): {
+    markdown: string;
+    slices: MarkdownSlice[];
+  } {
+    const updated = slices.map(s => ({ ...s }));
+    const target = updated.find(s => s.index === sliceIndex);
+    if (!target) {
+      return { markdown: this.reassemble(updated), slices: updated };
+    }
+
+    const oldLineCount = target.endLine - target.startLine;
+    const newLineCount = newRaw.split('\n').length;
+    const lineDelta = newLineCount - oldLineCount;
+
+    target.raw = newRaw;
+    target.endLine = target.startLine + newLineCount;
+
+    // Adjust subsequent slices
+    for (const s of updated) {
+      if (s.index !== sliceIndex && s.startLine >= target.startLine + oldLineCount) {
+        s.startLine += lineDelta;
+        s.endLine += lineDelta;
+      }
+    }
+
+    const markdown = this.reassemble(updated);
+    return { markdown, slices: updated };
+  }
+}

--- a/src/renderer/services/index.ts
+++ b/src/renderer/services/index.ts
@@ -13,3 +13,9 @@ export {
 export { DiffService } from './DiffService';
 
 export { FindService, type FindResult } from './FindService';
+
+export {
+  MarkdownSlicer,
+  type MarkdownSlice,
+  type SliceType,
+} from './MarkdownSlicer';

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -1,6 +1,7 @@
 import type {
   FileOpenResult,
   FileReadResult,
+  FileWriteResult,
   FileChangeEvent,
   FileDeleteEvent,
 } from './file';
@@ -22,6 +23,7 @@ export const IPC_CHANNELS = {
     READ: 'file:read',
     WATCH: 'file:watch',
     UNWATCH: 'file:unwatch',
+    WRITE: 'file:write',
     ON_CHANGE: 'file:on-change',
     ON_DELETE: 'file:on-delete',
   },
@@ -103,6 +105,7 @@ export interface FullscreenChangeEvent {
 export interface FileAPI {
   openDialog: () => Promise<FileOpenResult>;
   read: (filePath: string) => Promise<FileReadResult>;
+  write: (filePath: string, content: string) => Promise<FileWriteResult>;
   watch: (filePath: string) => Promise<void>;
   unwatch: (filePath: string) => Promise<void>;
   getDroppedFilePath: (file: File) => string;

--- a/src/shared/types/file.ts
+++ b/src/shared/types/file.ts
@@ -51,3 +51,11 @@ export interface FileChangeEvent {
 export interface FileDeleteEvent {
   filePath: string;
 }
+
+/**
+ * Result of writing a file
+ */
+export interface FileWriteResult {
+  success: boolean;
+  error?: string;
+}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -2,6 +2,7 @@
 export type {
   FileOpenResult,
   FileReadResult,
+  FileWriteResult,
   FileStats,
   WatchedFile,
   FileChangeEvent,

--- a/src/shared/types/preferences.ts
+++ b/src/shared/types/preferences.ts
@@ -90,6 +90,10 @@ export interface CorePreferences {
     ul: ListStyle;
     ol: ListStyle;
   };
+  editor: {
+    autoSave: boolean;
+    autoSaveDelay: number;
+  };
 }
 
 /**

--- a/tests/unit/main/ipc/handlers/ThemeHandler.test.ts
+++ b/tests/unit/main/ipc/handlers/ThemeHandler.test.ts
@@ -78,6 +78,7 @@ function createMockPreferencesService(initialMode: ThemeMode = 'system'): MockPr
         theme: { mode: currentMode, background: { light: '#fff', dark: '#000' } },
         typography: {} as AppPreferences['core']['typography'],
         lists: {} as AppPreferences['core']['lists'],
+        editor: { autoSave: true, autoSaveDelay: 1000 },
       },
       plugins: {},
     })),


### PR DESCRIPTION
## Summary
Implement a comprehensive edit mode for the markdown viewer that allows users to edit markdown content inline with a Notion-style interface. The content is split into individual "slices" (blocks) with hover states, left-side handles for options, and inline editing via textarea.

## Key Changes

### New Components
- **EditModeController** (`src/renderer/components/EditModeController.ts`): Manages edit mode with slice-based rendering, handling:
  - Slice creation and rendering with hover states
  - Inline editing via textarea with auto-resize
  - Context menu with block type conversion ("Turn into" submenu)
  - Slice actions: delete, duplicate, move up/down, add above/below
  - Auto-save integration with configurable delays
  - Event callbacks for content changes

- **MarkdownSlicer** (`src/renderer/services/MarkdownSlicer.ts`): Parses markdown into discrete blocks:
  - Splits markdown into individual slices (headings, paragraphs, lists, code blocks, blockquotes, tables, etc.)
  - Maintains line number tracking for accurate reassembly
  - Handles gap filling for unparsed content
  - Supports slice updates with automatic line number recalculation

### UI Updates
- **Toolbar**: Added edit mode toggle button and save button with visibility/enabled state management
- **MarkdownViewer**: Integrated edit mode entry/exit with callback support
- **Styling** (`src/index.css`): Comprehensive edit mode styles including:
  - Slice containers with hover effects
  - Left-side handle with grab cursor
  - Context menu with submenus for block type conversion
  - Textarea editor with auto-sizing
  - Block type badges (Aa, H1, H2, •, 1., etc.)

### File Operations
- **FileService**: Added `writeFile` capability for saving edited content
- **FileHandler**: Extended IPC handlers to support file writing

### Application State & Preferences
- **App**: Added edit mode state management with:
  - Auto-save timer with configurable delay
  - Unsaved changes tracking
  - File watching suspension during edit mode to prevent conflicts
  - Manual save trigger (Ctrl+S)
  - Edit mode toggle via menu and keyboard shortcut
  
- **Preferences**: Added editor configuration:
  - `autoSave`: Enable/disable automatic saving (default: true)
  - `autoSaveDelay`: Delay in milliseconds before auto-save (default: 1000ms)

### Type Definitions
- Added `FileWriteResult` type for file write operations
- Extended `CorePreferences` with editor settings
- Added `EditModeCallbacks` interface for edit mode events

## Implementation Details

- **Slice-based rendering**: Each markdown block is rendered as an independent DOM element with its own edit state, allowing granular control and efficient re-rendering
- **Notion-style UX**: Left-side handle with grip icon appears on hover, providing familiar interaction pattern for block manipulation
- **Block type conversion**: "Turn into" submenu allows converting between heading levels, lists, quotes, and code blocks while preserving content
- **Auto-save with debouncing**: Content changes trigger auto-save after configurable delay, with manual save option when auto-save is disabled
- **Conflict prevention**: File watching is suspended during edit mode to prevent external changes from interfering with editing
- **Plugin integration**: Post-render hooks run asynchronously to support dynamic content (e.g., Mermaid diagrams) in edit mode

https://claude.ai/code/session_011f55oA7WjintESk5h9rB7V