### PR TITLE
Add link hover preview to status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Link hover preview**: Hovering over a link in a rendered document now shows the target URL in the status bar
+
 ## [1.1.0] - 2025-01-21
 
 ### Added

--- a/index.html
+++ b/index.html
@@ -132,6 +132,7 @@
       <footer id="status-bar" class="status-bar">
         <div class="status-left">
           <span id="status-file-path" class="status-item" title="File path">No file</span>
+          <span id="status-link" class="status-item status-link" title="Link target"></span>
         </div>
         <div class="status-right">
           <span id="status-zoom" class="status-item status-zoom" title="Zoom level">100%</span>

--- a/src/index.css
+++ b/src/index.css
@@ -484,6 +484,18 @@ body {
   opacity: 1;
 }
 
+.status-link {
+  color: var(--link-color);
+  max-width: 60ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.status-link:empty {
+  display: none;
+}
+
 .status-zoom {
   font-variant-numeric: tabular-nums;
   min-width: 45px;

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -177,6 +177,8 @@ class App {
 
     this.findService = new FindService(viewerContainer);
 
+    this.setupLinkHover(viewerContainer);
+
     this.findBar = createFindBar(viewerElement, {
       onFind: (text, { matchCase }) => {
         const result = this.findService!.find(text, { matchCase });
@@ -283,6 +285,28 @@ class App {
     });
     this.dropZone.setOnOpenLinkClick(() => {
       void this.handleOpenFile();
+    });
+  }
+
+  /**
+   * Show the target URL in the status bar while hovering over a link
+   */
+  private setupLinkHover(container: HTMLElement): void {
+    const updateFromTarget = (target: EventTarget | null): void => {
+      const anchor =
+        target instanceof Element ? target.closest('a[href]') : null;
+      const href = anchor?.getAttribute('href') ?? null;
+      this.statusBar?.setLinkUrl(href);
+    };
+
+    container.addEventListener('mouseover', (e) => {
+      updateFromTarget(e.target);
+    });
+    container.addEventListener('mouseout', (e) => {
+      updateFromTarget(e.relatedTarget);
+    });
+    container.addEventListener('mouseleave', () => {
+      this.statusBar?.setLinkUrl(null);
     });
   }
 

--- a/src/renderer/components/StatusBar.ts
+++ b/src/renderer/components/StatusBar.ts
@@ -10,6 +10,7 @@ export interface StatusBarState {
   modifiedTime: Date | null;
   isWatching: boolean;
   zoomLevel: number;
+  linkUrl: string | null;
 }
 
 /**
@@ -22,11 +23,13 @@ export class StatusBar {
   private watchElement: HTMLElement | null = null;
   private watchTextElement: HTMLElement | null = null;
   private zoomElement: HTMLElement | null = null;
+  private linkElement: HTMLElement | null = null;
   private state: StatusBarState = {
     filePath: null,
     modifiedTime: null,
     isWatching: false,
     zoomLevel: 1.0,
+    linkUrl: null,
   };
 
   constructor(element: HTMLElement) {
@@ -43,6 +46,19 @@ export class StatusBar {
     this.watchElement = this.element.querySelector('#status-watch');
     this.watchTextElement = this.element.querySelector('#status-watch-text');
     this.zoomElement = this.element.querySelector('#status-zoom');
+    this.linkElement = this.element.querySelector('#status-link');
+  }
+
+  /**
+   * Update the hovered link URL display
+   */
+  setLinkUrl(linkUrl: string | null): void {
+    this.state.linkUrl = linkUrl;
+
+    if (this.linkElement) {
+      this.linkElement.textContent = linkUrl ?? '';
+      this.linkElement.title = linkUrl ?? '';
+    }
   }
 
   /**
@@ -152,6 +168,7 @@ export class StatusBar {
     this.setModifiedTime(null);
     this.setWatching(false);
     this.setZoomLevel(1.0);
+    this.setLinkUrl(null);
   }
 
   /**


### PR DESCRIPTION
## Summary
This PR adds a feature that displays the target URL of hovered links in the status bar, improving the user experience when viewing rendered markdown documents.

## Key Changes
- **Renderer**: Added `setupLinkHover()` method to track mouse events over links and update the status bar with the target URL
- **StatusBar**: 
  - Added `linkUrl` property to the state
  - Implemented `setLinkUrl()` method to update the link display
  - Added `#status-link` element reference and initialization
- **Styling**: Added `.status-link` CSS class with ellipsis truncation for long URLs and hide-when-empty behavior
- **HTML**: Added status link element to the status bar footer
- **Documentation**: Updated CHANGELOG with the new feature

## Implementation Details
- The link hover detection uses event delegation with `mouseover`, `mouseout`, and `mouseleave` events on the viewer container
- Links are identified using `closest('a[href]')` to handle clicks on nested elements within links
- The status bar element is hidden when empty using CSS (`:empty` pseudo-selector)
- Long URLs are truncated with ellipsis, limited to 60 characters width
- The implementation properly cleans up by clearing the link URL on `mouseleave`

https://claude.ai/code/session_0174FZDHzmNESyHbFdbd3giP