### PR TITLE
Live mermaid preview while editing + handle alignment fix

### DIFF
--- a/docs/superpowers/plans/2026-05-19-mermaid-live-preview.md
+++ b/docs/superpowers/plans/2026-05-19-mermaid-live-preview.md
@@ -1,0 +1,1537 @@
+# Live Mermaid Preview Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** While editing a mermaid block, show the rendered diagram above the source and update it in near-realtime as the user types. Generalise the mechanism so any plugin that renders a fenced code block can opt in.
+
+**Architecture:** A new optional plugin capability `PreviewablePlugin` (`matchesSlice`, `extractSource`, `renderPreview`, `applySourceToRaw`) and one new component `PreviewableSourceEditor` that owns the preview-above-textarea editing surface. `EditModeController.startEdit` gains a single new branch that opens the previewable editor for slices owned by a previewable plugin; mermaid is the first implementer.
+
+**Tech Stack:** TypeScript, Vitest (`environment: 'node'`, opt into jsdom per-file via `// @vitest-environment jsdom`), the existing `mermaid` module (already module-mocked in `MermaidPlugin.test.ts`).
+
+**Reference spec:** `docs/superpowers/specs/2026-05-19-mermaid-live-preview-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/plugins/types/preview.ts` (create) | Declares the `PreviewablePlugin` interface and a `isPreviewablePlugin` runtime type-guard. No runtime behaviour. |
+| `src/plugins/core/PluginManager.ts` (modify) | Adds `getPreviewablePlugins()` returning the subset of enabled plugins that implement the optional capability. |
+| `src/plugins/builtin/MermaidPlugin.ts` (modify) | Adds the four methods: `matchesSlice`, `extractSource`, `renderPreview`, `applySourceToRaw`. Existing `apply` and `postRender` paths unchanged. |
+| `src/renderer/components/PreviewableSourceEditor.ts` (create) | One editing session. Builds preview/error-chip/textarea DOM, drives debounced re-render with race control, idempotent commit. |
+| `src/renderer/components/EditModeController.ts` (modify) | `findPreviewablePluginFor(slice)` lookup, one new branch in `startEdit`, dispatch in `commitActiveEdit`. Factor `commitRawEdit`'s post-update + re-render path into a shared `applyRawCommit` helper. |
+| `src/index.css` (modify) | Styles for `.preview-source-preview`, `.preview-source-error`. |
+| `tests/unit/plugins/builtin/MermaidPlugin.test.ts` (modify) | Add suites for the four new methods. |
+| `tests/unit/renderer/components/PreviewableSourceEditor.test.ts` (create) | DOM-lifecycle, debounced render, race control, error chip, commit. |
+| `tests/unit/renderer/components/EditModeController.test.ts` (modify) | Mermaid slice → previewable editor; other code blocks → raw editor; paragraph → WYSIWYG; commit updates slice. |
+
+**DOM-construction note:** test fixtures build DOM with `element.insertAdjacentHTML('afterbegin', html)` and production re-renders use `replaceChildren()` + `insertAdjacentHTML('afterbegin', html)`. Matches the existing slice-menu code in `EditModeController`.
+
+---
+
+## Task 1: `PreviewablePlugin` interface + type guard
+
+**Files:**
+- Create: `src/plugins/types/preview.ts`
+
+This is a pure type declaration. No tests; subsequent tasks exercise it through their consumers.
+
+- [ ] **Step 1: Create the file**
+
+```ts
+/**
+ * PreviewablePlugin - Optional plugin capability for live-preview editing.
+ *
+ * A plugin that owns a particular kind of slice (e.g. MermaidPlugin owns
+ * ```mermaid fences) implements this so the editor can give the user a
+ * live-preview-above-source editing surface. The four methods are stateless
+ * on the plugin: matchesSlice/extractSource/applySourceToRaw are pure;
+ * renderPreview is async and mutates the target element.
+ */
+import type { MarkdownPlugin } from '@shared/types';
+import type { MarkdownSlice } from '../../renderer/services/MarkdownSlicer';
+
+export interface PreviewablePlugin {
+  /** Does this plugin own the given slice? Fast and side-effect-free. */
+  matchesSlice(slice: MarkdownSlice): boolean;
+
+  /** Extract the user-editable source from the slice's raw markdown
+   *  (e.g. strip ```mermaid fences). */
+  extractSource(slice: MarkdownSlice): string;
+
+  /** Render `source` into `target`, replacing its contents on success.
+   *  MUST NOT throw — errors are returned so the caller can keep the
+   *  previous good preview visible. On `{ ok: false }` `target` MUST
+   *  be left unchanged. */
+  renderPreview(
+    source: string,
+    target: HTMLElement,
+  ): Promise<{ ok: true } | { ok: false; error: string }>;
+
+  /** Inverse of extractSource — wrap the edited source back into a full
+   *  slice raw. Implementations may consult `slice.raw` to preserve
+   *  details like a fence's info-string. */
+  applySourceToRaw(slice: MarkdownSlice, source: string): string;
+}
+
+/** Runtime duck-type check. Returns true when `plugin` implements all four
+ *  PreviewablePlugin methods. */
+export function isPreviewablePlugin(
+  plugin: MarkdownPlugin,
+): plugin is MarkdownPlugin & PreviewablePlugin {
+  const p = plugin as Partial<PreviewablePlugin>;
+  return typeof p.matchesSlice === 'function'
+      && typeof p.extractSource === 'function'
+      && typeof p.renderPreview === 'function'
+      && typeof p.applySourceToRaw === 'function';
+}
+```
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `pnpm typecheck`
+Expected: PASS — no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/plugins/types/preview.ts
+git commit -m "feat: declare PreviewablePlugin capability interface"
+```
+
+---
+
+## Task 2: `PluginManager.getPreviewablePlugins()`
+
+**Files:**
+- Modify: `src/plugins/core/PluginManager.ts`
+- Test: `tests/unit/plugins/core/PluginManager.test.ts`
+
+- [ ] **Step 1: Write the failing test (append a new describe block)**
+
+```ts
+import {
+  isPreviewablePlugin,
+  type PreviewablePlugin,
+} from '@plugins/types/preview';
+import type { MarkdownPlugin } from '@shared/types';
+
+function fakePreviewablePlugin(id: string): MarkdownPlugin & PreviewablePlugin {
+  return {
+    metadata: { id, name: id, version: '1.0.0', description: '' },
+    matchesSlice: () => false,
+    extractSource: () => '',
+    renderPreview: async () => ({ ok: true }),
+    applySourceToRaw: (_s, source) => source,
+  };
+}
+
+describe('getPreviewablePlugins', () => {
+  it('returns only enabled plugins that implement the previewable capability', async () => {
+    const pm = new PluginManager();
+    pm.registerPluginFactory('mermaid-like', () => fakePreviewablePlugin('mermaid-like'));
+    pm.registerPluginFactory('plain', () => ({
+      metadata: { id: 'plain', name: 'plain', version: '1.0.0', description: '' },
+    }));
+    await pm.enablePlugin('mermaid-like');
+    await pm.enablePlugin('plain');
+
+    const previewable = pm.getPreviewablePlugins();
+    expect(previewable).toHaveLength(1);
+    expect(isPreviewablePlugin(previewable[0]!)).toBe(true);
+    expect(previewable[0]!.metadata.id).toBe('mermaid-like');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/plugins/core/PluginManager.test.ts`
+Expected: FAIL — `pm.getPreviewablePlugins is not a function`.
+
+- [ ] **Step 3: Add the implementation**
+
+Add an import at the top of `src/plugins/core/PluginManager.ts`:
+
+```ts
+import { isPreviewablePlugin, type PreviewablePlugin } from '../types/preview';
+import type { MarkdownPlugin } from '@shared/types';
+```
+
+Add this method to the `PluginManager` class near `getPlugin`:
+
+```ts
+  /**
+   * Return all enabled plugins that implement the PreviewablePlugin
+   * capability. Order matches the order plugins were enabled.
+   */
+  getPreviewablePlugins(): (MarkdownPlugin & PreviewablePlugin)[] {
+    const result: (MarkdownPlugin & PreviewablePlugin)[] = [];
+    for (const id of this.renderer.getEnabledPlugins()) {
+      const plugin = this.renderer.getPlugin(id);
+      if (plugin && isPreviewablePlugin(plugin)) {
+        result.push(plugin);
+      }
+    }
+    return result;
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/unit/plugins/core/PluginManager.test.ts`
+Expected: PASS — all suites green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/plugins/core/PluginManager.ts tests/unit/plugins/core/PluginManager.test.ts
+git commit -m "feat: PluginManager.getPreviewablePlugins"
+```
+
+---
+
+## Task 3: `MermaidPlugin.matchesSlice`
+
+**Files:**
+- Modify: `src/plugins/builtin/MermaidPlugin.ts`
+- Test: `tests/unit/plugins/builtin/MermaidPlugin.test.ts`
+
+- [ ] **Step 1: Write the failing test (append a new describe block)**
+
+```ts
+import type { MarkdownSlice } from '@renderer/services/MarkdownSlicer';
+
+function slice(partial: Partial<MarkdownSlice>): MarkdownSlice {
+  return {
+    index: 0,
+    type: 'code',
+    raw: '',
+    startLine: 0,
+    endLine: 0,
+    ...partial,
+  };
+}
+
+describe('matchesSlice', () => {
+  it('returns true for a code slice with a ```mermaid opening fence', () => {
+    expect(plugin.matchesSlice(slice({ raw: '```mermaid\nA --> B\n```' }))).toBe(true);
+  });
+
+  it('returns true when the mermaid fence has an info-string suffix', () => {
+    expect(plugin.matchesSlice(slice({ raw: '```mermaid theme=dark\nA --> B\n```' }))).toBe(true);
+  });
+
+  it('returns false for a code slice in another language', () => {
+    expect(plugin.matchesSlice(slice({ raw: '```js\nconsole.log(1);\n```' }))).toBe(false);
+  });
+
+  it('returns false for non-code slice types', () => {
+    expect(plugin.matchesSlice(slice({ type: 'paragraph', raw: 'mermaid' }))).toBe(false);
+  });
+
+  it('returns false when the slice has no opening fence', () => {
+    expect(plugin.matchesSlice(slice({ raw: 'graph TD\nA --> B' }))).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/plugins/builtin/MermaidPlugin.test.ts`
+Expected: FAIL — `plugin.matchesSlice is not a function`.
+
+- [ ] **Step 3: Add the implementation**
+
+Add an import at the top of `src/plugins/builtin/MermaidPlugin.ts`:
+
+```ts
+import type { PreviewablePlugin } from '../types/preview';
+import type { MarkdownSlice } from '../../renderer/services/MarkdownSlicer';
+```
+
+Change the class signature:
+
+```ts
+export class MermaidPlugin implements MarkdownPlugin, PreviewablePlugin {
+```
+
+Add the method to the class:
+
+```ts
+  matchesSlice(slice: MarkdownSlice): boolean {
+    if (slice.type !== 'code') return false;
+    const firstLine = slice.raw.trimStart().split('\n', 1)[0] ?? '';
+    return /^```mermaid\b/.test(firstLine);
+  }
+```
+
+The class will fail to compile (PreviewablePlugin is missing three more methods). To keep typecheck green until the next tasks land, add stubs that throw:
+
+```ts
+  extractSource(_slice: MarkdownSlice): string {
+    throw new Error('not implemented');
+  }
+  async renderPreview(
+    _source: string,
+    _target: HTMLElement,
+  ): Promise<{ ok: true } | { ok: false; error: string }> {
+    throw new Error('not implemented');
+  }
+  applySourceToRaw(_slice: MarkdownSlice, _source: string): string {
+    throw new Error('not implemented');
+  }
+```
+
+Tasks 4-6 replace each stub with a real implementation.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/unit/plugins/builtin/MermaidPlugin.test.ts`
+Expected: PASS — matchesSlice tests pass; the stubbed methods aren't exercised yet.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/plugins/builtin/MermaidPlugin.ts tests/unit/plugins/builtin/MermaidPlugin.test.ts
+git commit -m "feat: MermaidPlugin.matchesSlice"
+```
+
+---
+
+## Task 4: `MermaidPlugin.extractSource`
+
+**Files:**
+- Modify: `src/plugins/builtin/MermaidPlugin.ts`
+- Test: `tests/unit/plugins/builtin/MermaidPlugin.test.ts`
+
+- [ ] **Step 1: Write the failing test (append a new describe block)**
+
+```ts
+describe('extractSource', () => {
+  it('strips opening ```mermaid fence and closing ``` fence', () => {
+    const s = slice({ raw: '```mermaid\ngraph TD\nA --> B\n```' });
+    expect(plugin.extractSource(s)).toBe('graph TD\nA --> B');
+  });
+
+  it('strips opening fence with info-string suffix', () => {
+    const s = slice({ raw: '```mermaid theme=dark\ngraph TD\nA --> B\n```' });
+    expect(plugin.extractSource(s)).toBe('graph TD\nA --> B');
+  });
+
+  it('preserves blank lines and trailing whitespace inside the content', () => {
+    const s = slice({ raw: '```mermaid\ngraph TD\n\n  A --> B\n```' });
+    expect(plugin.extractSource(s)).toBe('graph TD\n\n  A --> B');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/plugins/builtin/MermaidPlugin.test.ts`
+Expected: FAIL — `extractSource` throws `not implemented`.
+
+- [ ] **Step 3: Replace the stub**
+
+In `src/plugins/builtin/MermaidPlugin.ts`, replace the `extractSource` stub with:
+
+```ts
+  extractSource(slice: MarkdownSlice): string {
+    const lines = slice.raw.split('\n');
+    let start = 0;
+    let end = lines.length;
+    if (lines[0]?.trimStart().startsWith('```mermaid')) start = 1;
+    if (lines[lines.length - 1]?.trim() === '```') end = lines.length - 1;
+    return lines.slice(start, end).join('\n');
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/unit/plugins/builtin/MermaidPlugin.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/plugins/builtin/MermaidPlugin.ts tests/unit/plugins/builtin/MermaidPlugin.test.ts
+git commit -m "feat: MermaidPlugin.extractSource"
+```
+
+---
+
+## Task 5: `MermaidPlugin.applySourceToRaw`
+
+**Files:**
+- Modify: `src/plugins/builtin/MermaidPlugin.ts`
+- Test: `tests/unit/plugins/builtin/MermaidPlugin.test.ts`
+
+- [ ] **Step 1: Write the failing test (append a new describe block)**
+
+```ts
+describe('applySourceToRaw', () => {
+  it("re-wraps source with the slice's original opening info-string", () => {
+    const s = slice({ raw: '```mermaid\nold\n```' });
+    expect(plugin.applySourceToRaw(s, 'graph TD\nA --> B')).toBe(
+      '```mermaid\ngraph TD\nA --> B\n```',
+    );
+  });
+
+  it('preserves an info-string suffix on the opening fence', () => {
+    const s = slice({ raw: '```mermaid theme=dark\nold\n```' });
+    expect(plugin.applySourceToRaw(s, 'graph TD\nA --> B')).toBe(
+      '```mermaid theme=dark\ngraph TD\nA --> B\n```',
+    );
+  });
+
+  it('falls back to "mermaid" when slice.raw has no recognisable opening fence', () => {
+    const s = slice({ raw: 'no fence' });
+    expect(plugin.applySourceToRaw(s, 'graph TD')).toBe('```mermaid\ngraph TD\n```');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/plugins/builtin/MermaidPlugin.test.ts`
+Expected: FAIL — `applySourceToRaw` throws `not implemented`.
+
+- [ ] **Step 3: Replace the stub**
+
+```ts
+  applySourceToRaw(slice: MarkdownSlice, source: string): string {
+    const firstLine = slice.raw.trimStart().split('\n', 1)[0] ?? '';
+    const match = firstLine.match(/^```(.*)$/);
+    const info = match?.[1] ?? 'mermaid';
+    return '```' + info + '\n' + source + '\n```';
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/unit/plugins/builtin/MermaidPlugin.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/plugins/builtin/MermaidPlugin.ts tests/unit/plugins/builtin/MermaidPlugin.test.ts
+git commit -m "feat: MermaidPlugin.applySourceToRaw preserves info-string"
+```
+
+---
+
+## Task 6: `MermaidPlugin.renderPreview`
+
+**Files:**
+- Modify: `src/plugins/builtin/MermaidPlugin.ts`
+- Test: `tests/unit/plugins/builtin/MermaidPlugin.test.ts`
+
+- [ ] **Step 1: Write the failing test (append a new describe block)**
+
+```ts
+/**
+ * @vitest-environment jsdom
+ */
+// NOTE: This describe needs the DOM; ensure the file's first-line annotation
+// is `@vitest-environment jsdom`. The existing MermaidPlugin.test.ts already
+// uses jsdom — if not, add the annotation to the top of the file.
+
+describe('renderPreview', () => {
+  it('replaces target contents with rendered SVG on success', async () => {
+    const target = document.createElement('div');
+    target.textContent = 'placeholder';
+    const result = await plugin.renderPreview('graph TD\nA --> B', target);
+    expect(result).toEqual({ ok: true });
+    expect(target.children.length).toBe(1);
+    expect(target.children[0]!.tagName.toLowerCase()).toBe('svg');
+    expect(target.textContent).toBe('Mock SVG');
+  });
+
+  it('leaves target untouched and returns the error on failure', async () => {
+    const mermaid = (await import('mermaid')).default;
+    vi.mocked(mermaid.render).mockRejectedValueOnce(new Error('Parse error'));
+    const target = document.createElement('div');
+    target.textContent = 'previous good preview';
+    const result = await plugin.renderPreview('bogus', target);
+    expect(result).toEqual({ ok: false, error: 'Parse error' });
+    expect(target.textContent).toBe('previous good preview');
+  });
+
+  it('returns an error when the mermaid library is not initialised', async () => {
+    const uninit = new MermaidPlugin();
+    const target = document.createElement('div');
+    const result = await uninit.renderPreview('graph TD', target);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/not initialised/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/plugins/builtin/MermaidPlugin.test.ts`
+Expected: FAIL — `renderPreview` throws `not implemented`.
+
+- [ ] **Step 3: Replace the stub**
+
+```ts
+  async renderPreview(
+    source: string,
+    target: HTMLElement,
+  ): Promise<{ ok: true } | { ok: false; error: string }> {
+    if (!this.mermaid) return { ok: false, error: 'Mermaid not initialised' };
+    try {
+      const id = `mermaid-preview-${this.diagramCounter++}`;
+      const { svg } = await this.mermaid.render(id, source);
+      target.replaceChildren();
+      target.insertAdjacentHTML('afterbegin', svg);
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : String(e) };
+    }
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/unit/plugins/builtin/MermaidPlugin.test.ts`
+Expected: PASS — all MermaidPlugin tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/plugins/builtin/MermaidPlugin.ts tests/unit/plugins/builtin/MermaidPlugin.test.ts
+git commit -m "feat: MermaidPlugin.renderPreview with contract-conforming error handling"
+```
+
+---
+
+## Task 7: `PreviewableSourceEditor` lifecycle (start + idempotent commit)
+
+**Files:**
+- Create: `src/renderer/components/PreviewableSourceEditor.ts`
+- Test: `tests/unit/renderer/components/PreviewableSourceEditor.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { PreviewableSourceEditor } from '../../../../src/renderer/components/PreviewableSourceEditor';
+import type { PreviewablePlugin } from '../../../../src/plugins/types/preview';
+import type { MarkdownSlice } from '../../../../src/renderer/services/MarkdownSlicer';
+import type { MarkdownPlugin } from '../../../../src/shared/types';
+
+function contentEl(html: string): HTMLElement {
+  const el = document.createElement('div');
+  el.className = 'slice-content';
+  el.insertAdjacentHTML('afterbegin', html);
+  document.body.appendChild(el);
+  return el;
+}
+
+function slice(partial: Partial<MarkdownSlice> = {}): MarkdownSlice {
+  return { index: 0, type: 'code', raw: '```mermaid\nA --> B\n```', startLine: 0, endLine: 2, ...partial };
+}
+
+function fakePlugin(overrides: Partial<PreviewablePlugin> = {}): MarkdownPlugin & PreviewablePlugin {
+  return {
+    metadata: { id: 'fake', name: 'fake', version: '1.0.0', description: '' },
+    matchesSlice: () => true,
+    extractSource: () => 'A --> B',
+    renderPreview: vi.fn(async () => ({ ok: true })),
+    applySourceToRaw: (_s, source) => '```mermaid\n' + source + '\n```',
+    ...overrides,
+  };
+}
+
+describe('PreviewableSourceEditor lifecycle', () => {
+  it('start() builds preview/error-chip/textarea structure inside contentEl', () => {
+    const el = contentEl('<div class="mermaid-container"><svg>old</svg></div>');
+    const editor = new PreviewableSourceEditor(el, slice(), fakePlugin(), { onCommit: vi.fn() });
+    editor.start();
+    expect(el.querySelector('.preview-source-preview')).not.toBe(null);
+    expect(el.querySelector('.preview-source-error')).not.toBe(null);
+    expect(el.querySelector('textarea.slice-raw-editor')).not.toBe(null);
+    // existing rendered SVG was moved into the preview area
+    const movedSvg = el.querySelector('.preview-source-preview .mermaid-container svg');
+    expect(movedSvg).not.toBe(null);
+    expect(movedSvg!.textContent).toBe('old');
+  });
+
+  it('start() seeds textarea with plugin.extractSource and focuses it', () => {
+    const el = contentEl('<div class="mermaid-container"></div>');
+    const editor = new PreviewableSourceEditor(el, slice(), fakePlugin(), { onCommit: vi.fn() });
+    editor.start();
+    const ta = el.querySelector<HTMLTextAreaElement>('textarea')!;
+    expect(ta.value).toBe('A --> B');
+    expect(document.activeElement).toBe(ta);
+  });
+
+  it('start() hides the error chip initially', () => {
+    const el = contentEl('<div class="mermaid-container"></div>');
+    const editor = new PreviewableSourceEditor(el, slice(), fakePlugin(), { onCommit: vi.fn() });
+    editor.start();
+    expect(el.querySelector<HTMLElement>('.preview-source-error')!.hidden).toBe(true);
+  });
+
+  it('commit() calls plugin.applySourceToRaw with the textarea value and forwards to onCommit', () => {
+    const el = contentEl('<div class="mermaid-container"></div>');
+    const onCommit = vi.fn();
+    const editor = new PreviewableSourceEditor(el, slice(), fakePlugin(), { onCommit });
+    editor.start();
+    el.querySelector<HTMLTextAreaElement>('textarea')!.value = 'C --> D';
+    editor.commit();
+    expect(onCommit).toHaveBeenCalledWith('```mermaid\nC --> D\n```');
+  });
+
+  it('commit() is idempotent — a second call is a no-op', () => {
+    const el = contentEl('<div class="mermaid-container"></div>');
+    const onCommit = vi.fn();
+    const editor = new PreviewableSourceEditor(el, slice(), fakePlugin(), { onCommit });
+    editor.start();
+    editor.commit();
+    editor.commit();
+    expect(onCommit).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/renderer/components/PreviewableSourceEditor.test.ts`
+Expected: FAIL — cannot resolve `PreviewableSourceEditor`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+```ts
+/**
+ * PreviewableSourceEditor - Drives a "preview above source" editing session
+ * for a slice owned by a PreviewablePlugin.
+ *
+ * Layout it builds inside the passed-in `.slice-content`:
+ *
+ *   <div class="slice-content">
+ *     <div class="preview-source-preview">   ← preview (top, populated initially
+ *                                              with the existing rendered content
+ *                                              moved from the slice-content)
+ *     <div class="preview-source-error" hidden>
+ *       <span class="preview-source-error-text"></span>
+ *     <textarea class="slice-raw-editor">    ← editor (bottom)
+ *
+ * Subsequent tasks add: debounced re-render on input (Task 8), race control
+ * (Task 9), error chip toggling (Task 10), Esc-commits (Task 11).
+ */
+import type { MarkdownSlice } from '../services/MarkdownSlicer';
+import type { PreviewablePlugin } from '../../plugins/types/preview';
+
+export interface PreviewableSourceEditorCallbacks {
+  /** Called once when the session commits, with the slice's new raw markdown. */
+  onCommit: (newRaw: string) => void;
+}
+
+export class PreviewableSourceEditor {
+  private el: HTMLElement;
+  private slice: MarkdownSlice;
+  private plugin: PreviewablePlugin;
+  private callbacks: PreviewableSourceEditorCallbacks;
+  private committed = false;
+  private previewEl!: HTMLElement;
+  private errorEl!: HTMLElement;
+  private errorTextEl!: HTMLElement;
+  private textarea!: HTMLTextAreaElement;
+
+  constructor(
+    el: HTMLElement,
+    slice: MarkdownSlice,
+    plugin: PreviewablePlugin,
+    callbacks: PreviewableSourceEditorCallbacks,
+  ) {
+    this.el = el;
+    this.slice = slice;
+    this.plugin = plugin;
+    this.callbacks = callbacks;
+  }
+
+  start(): void {
+    // Capture the slice-content's current children (the existing rendered
+    // preview, e.g. a <div.mermaid-container> with SVG) — we'll move them
+    // into the new preview area below.
+    const existingChildren = Array.from(this.el.childNodes);
+
+    this.previewEl = document.createElement('div');
+    this.previewEl.className = 'preview-source-preview';
+    for (const child of existingChildren) this.previewEl.appendChild(child);
+
+    this.errorEl = document.createElement('div');
+    this.errorEl.className = 'preview-source-error';
+    this.errorEl.hidden = true;
+    this.errorTextEl = document.createElement('span');
+    this.errorTextEl.className = 'preview-source-error-text';
+    this.errorEl.appendChild(this.errorTextEl);
+
+    this.textarea = document.createElement('textarea');
+    this.textarea.className = 'slice-raw-editor';
+    this.textarea.spellcheck = false;
+    this.textarea.value = this.plugin.extractSource(this.slice);
+
+    this.el.replaceChildren(this.previewEl, this.errorEl, this.textarea);
+    this.textarea.focus();
+  }
+
+  commit(): void {
+    if (this.committed) return;
+    this.committed = true;
+    const newRaw = this.plugin.applySourceToRaw(this.slice, this.textarea.value);
+    this.callbacks.onCommit(newRaw);
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/unit/renderer/components/PreviewableSourceEditor.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/components/PreviewableSourceEditor.ts tests/unit/renderer/components/PreviewableSourceEditor.test.ts
+git commit -m "feat: add PreviewableSourceEditor lifecycle and commit"
+```
+
+---
+
+## Task 8: `PreviewableSourceEditor` — debounced renderPreview on input
+
+**Files:**
+- Modify: `src/renderer/components/PreviewableSourceEditor.ts`
+- Test: `tests/unit/renderer/components/PreviewableSourceEditor.test.ts`
+
+- [ ] **Step 1: Write the failing test (append)**
+
+```ts
+describe('PreviewableSourceEditor debounced render', () => {
+  it('calls plugin.renderPreview after a 250ms pause in typing', async () => {
+    vi.useFakeTimers();
+    try {
+      const el = contentEl('<div class="mermaid-container"></div>');
+      const plugin = fakePlugin();
+      const editor = new PreviewableSourceEditor(el, slice(), plugin, { onCommit: vi.fn() });
+      editor.start();
+      const ta = el.querySelector<HTMLTextAreaElement>('textarea')!;
+      ta.value = 'X --> Y';
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+      expect(plugin.renderPreview).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(250);
+      expect(plugin.renderPreview).toHaveBeenCalledTimes(1);
+      expect(plugin.renderPreview).toHaveBeenCalledWith('X --> Y', expect.any(HTMLElement));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('coalesces rapid keystrokes into one render after the pause', async () => {
+    vi.useFakeTimers();
+    try {
+      const el = contentEl('<div class="mermaid-container"></div>');
+      const plugin = fakePlugin();
+      const editor = new PreviewableSourceEditor(el, slice(), plugin, { onCommit: vi.fn() });
+      editor.start();
+      const ta = el.querySelector<HTMLTextAreaElement>('textarea')!;
+      for (const v of ['a', 'ab', 'abc', 'abcd']) {
+        ta.value = v;
+        ta.dispatchEvent(new Event('input', { bubbles: true }));
+        await vi.advanceTimersByTimeAsync(100); // less than 250ms
+      }
+      expect(plugin.renderPreview).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(250);
+      expect(plugin.renderPreview).toHaveBeenCalledTimes(1);
+      expect(plugin.renderPreview).toHaveBeenCalledWith('abcd', expect.any(HTMLElement));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('replaces preview contents on { ok: true }', async () => {
+    vi.useFakeTimers();
+    try {
+      const el = contentEl('<div class="mermaid-container"><svg>old</svg></div>');
+      const plugin = fakePlugin({
+        renderPreview: vi.fn(async (_src, target) => {
+          target.replaceChildren();
+          target.insertAdjacentHTML('afterbegin', '<svg>new</svg>');
+          return { ok: true };
+        }),
+      });
+      const editor = new PreviewableSourceEditor(el, slice(), plugin, { onCommit: vi.fn() });
+      editor.start();
+      const ta = el.querySelector<HTMLTextAreaElement>('textarea')!;
+      ta.value = 'X --> Y';
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.runAllTimersAsync();
+      const previewSvg = el.querySelector('.preview-source-preview > svg');
+      expect(previewSvg).not.toBe(null);
+      expect(previewSvg!.textContent).toBe('new');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('cancels a pending debounced render when commit is called', async () => {
+    vi.useFakeTimers();
+    try {
+      const el = contentEl('<div class="mermaid-container"></div>');
+      const plugin = fakePlugin();
+      const editor = new PreviewableSourceEditor(el, slice(), plugin, { onCommit: vi.fn() });
+      editor.start();
+      const ta = el.querySelector<HTMLTextAreaElement>('textarea')!;
+      ta.value = 'X --> Y';
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+      editor.commit();
+      await vi.advanceTimersByTimeAsync(500);
+      expect(plugin.renderPreview).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/renderer/components/PreviewableSourceEditor.test.ts`
+Expected: FAIL — no debounced render wired.
+
+- [ ] **Step 3: Add the implementation**
+
+Add a constant near the top of `src/renderer/components/PreviewableSourceEditor.ts`:
+
+```ts
+const DEBOUNCE_MS = 250;
+```
+
+Add a field on the class:
+
+```ts
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+```
+
+Extend `start()` to wire the input listener (add after `this.textarea.focus();`):
+
+```ts
+    this.textarea.addEventListener('input', this.onInput);
+```
+
+Extend `commit()` to clear the pending timer FIRST (before the idempotence guard's return is hit on later calls):
+
+```ts
+  commit(): void {
+    if (this.committed) return;
+    this.committed = true;
+    if (this.debounceTimer !== null) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    this.textarea.removeEventListener('input', this.onInput);
+    const newRaw = this.plugin.applySourceToRaw(this.slice, this.textarea.value);
+    this.callbacks.onCommit(newRaw);
+  }
+```
+
+Add the handler as a bound class field (so add/removeEventListener share the reference):
+
+```ts
+  private readonly onInput = (): void => {
+    if (this.debounceTimer !== null) clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      void this.runRender();
+    }, DEBOUNCE_MS);
+  };
+
+  private async runRender(): Promise<void> {
+    const source = this.textarea.value;
+    await this.plugin.renderPreview(source, this.previewEl);
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/unit/renderer/components/PreviewableSourceEditor.test.ts`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/components/PreviewableSourceEditor.ts tests/unit/renderer/components/PreviewableSourceEditor.test.ts
+git commit -m "feat: PreviewableSourceEditor debounced re-render on input"
+```
+
+---
+
+## Task 9: `PreviewableSourceEditor` — race control (monotonic requestId)
+
+**Files:**
+- Modify: `src/renderer/components/PreviewableSourceEditor.ts`
+- Test: `tests/unit/renderer/components/PreviewableSourceEditor.test.ts`
+
+- [ ] **Step 1: Write the failing test (append)**
+
+```ts
+describe('PreviewableSourceEditor race control', () => {
+  it('drops a slow earlier render result when a newer render has fired', async () => {
+    vi.useFakeTimers();
+    try {
+      const el = contentEl('<div class="mermaid-container">initial</div>');
+      let resolveFirst!: () => void;
+      const firstPromise = new Promise<void>((r) => { resolveFirst = r; });
+      const renderPreview = vi.fn(async (source: string, target: HTMLElement) => {
+        if (source === 'slow') {
+          await firstPromise;
+          target.replaceChildren();
+          target.insertAdjacentHTML('afterbegin', '<svg>slow</svg>');
+          return { ok: true as const };
+        }
+        target.replaceChildren();
+        target.insertAdjacentHTML('afterbegin', '<svg>fast</svg>');
+        return { ok: true as const };
+      });
+      const plugin = fakePlugin({ renderPreview });
+      const editor = new PreviewableSourceEditor(el, slice(), plugin, { onCommit: vi.fn() });
+      editor.start();
+      const ta = el.querySelector<HTMLTextAreaElement>('textarea')!;
+
+      ta.value = 'slow';
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+      await vi.advanceTimersByTimeAsync(250); // first render starts but is awaiting
+
+      ta.value = 'fast';
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+      await vi.advanceTimersByTimeAsync(250); // second render starts and completes
+      await vi.runAllTimersAsync();
+
+      // Now release the slow first render — it should NOT overwrite "fast".
+      resolveFirst();
+      await vi.runAllTimersAsync();
+
+      const previewSvg = el.querySelector('.preview-source-preview > svg');
+      expect(previewSvg).not.toBe(null);
+      expect(previewSvg!.textContent).toBe('fast');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/renderer/components/PreviewableSourceEditor.test.ts`
+Expected: FAIL — slow render's `target.replaceChildren()` clobbers the fast result.
+
+- [ ] **Step 3: Add the implementation**
+
+Race control needs the plugin's `renderPreview` to be allowed to mutate `target`, but only the LATEST render result should be visible. We achieve this by giving each render its own scratch container and only swapping the scratch into the live preview if it's still the latest.
+
+Add a field:
+
+```ts
+  private latestRenderId = 0;
+```
+
+Replace `runRender` with:
+
+```ts
+  private async runRender(): Promise<void> {
+    const myId = ++this.latestRenderId;
+    const source = this.textarea.value;
+    const scratch = document.createElement('div');
+    const result = await this.plugin.renderPreview(source, scratch);
+    if (this.committed || myId !== this.latestRenderId) return;
+    if (result.ok) {
+      this.previewEl.replaceChildren(...Array.from(scratch.childNodes));
+    }
+    // {ok: false} handling is added in Task 10.
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/unit/renderer/components/PreviewableSourceEditor.test.ts`
+Expected: PASS (10 tests). The earlier "replaces preview contents on { ok: true }" test still passes because the scratch's SVG node is moved (not cloned) into the preview area.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/components/PreviewableSourceEditor.ts tests/unit/renderer/components/PreviewableSourceEditor.test.ts
+git commit -m "feat: PreviewableSourceEditor — last keystroke wins via monotonic id"
+```
+
+---
+
+## Task 10: `PreviewableSourceEditor` — error chip on `{ ok: false }`
+
+**Files:**
+- Modify: `src/renderer/components/PreviewableSourceEditor.ts`
+- Test: `tests/unit/renderer/components/PreviewableSourceEditor.test.ts`
+
+- [ ] **Step 1: Write the failing test (append)**
+
+```ts
+describe('PreviewableSourceEditor error handling', () => {
+  it('keeps the previous preview and shows the error chip on { ok: false }', async () => {
+    vi.useFakeTimers();
+    try {
+      const el = contentEl('<div class="mermaid-container"><svg>good</svg></div>');
+      const plugin = fakePlugin({
+        renderPreview: vi.fn(async () => ({ ok: false as const, error: 'Syntax error: foo' })),
+      });
+      const editor = new PreviewableSourceEditor(el, slice(), plugin, { onCommit: vi.fn() });
+      editor.start();
+      const ta = el.querySelector<HTMLTextAreaElement>('textarea')!;
+      ta.value = 'bad';
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.runAllTimersAsync();
+
+      // Previous preview untouched
+      const previewSvg = el.querySelector('.preview-source-preview .mermaid-container svg');
+      expect(previewSvg!.textContent).toBe('good');
+      // Error chip visible with the message
+      const errorChip = el.querySelector<HTMLElement>('.preview-source-error')!;
+      expect(errorChip.hidden).toBe(false);
+      expect(errorChip.querySelector('.preview-source-error-text')!.textContent).toBe('Syntax error: foo');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('hides the error chip again on the next successful render', async () => {
+    vi.useFakeTimers();
+    try {
+      const el = contentEl('<div class="mermaid-container"><svg>good</svg></div>');
+      let next: { ok: true } | { ok: false; error: string } = { ok: false, error: 'oops' };
+      const plugin = fakePlugin({
+        renderPreview: vi.fn(async (_src, target) => {
+          if (next.ok) {
+            target.replaceChildren();
+            target.insertAdjacentHTML('afterbegin', '<svg>new</svg>');
+          }
+          return next;
+        }),
+      });
+      const editor = new PreviewableSourceEditor(el, slice(), plugin, { onCommit: vi.fn() });
+      editor.start();
+      const ta = el.querySelector<HTMLTextAreaElement>('textarea')!;
+
+      ta.value = 'bad';
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.runAllTimersAsync();
+      expect(el.querySelector<HTMLElement>('.preview-source-error')!.hidden).toBe(false);
+
+      next = { ok: true };
+      ta.value = 'good';
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.runAllTimersAsync();
+      expect(el.querySelector<HTMLElement>('.preview-source-error')!.hidden).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/renderer/components/PreviewableSourceEditor.test.ts`
+Expected: FAIL — error chip never becomes visible.
+
+- [ ] **Step 3: Add the implementation**
+
+Extend `runRender` to surface errors:
+
+```ts
+  private async runRender(): Promise<void> {
+    const myId = ++this.latestRenderId;
+    const source = this.textarea.value;
+    const scratch = document.createElement('div');
+    const result = await this.plugin.renderPreview(source, scratch);
+    if (this.committed || myId !== this.latestRenderId) return;
+    if (result.ok) {
+      this.previewEl.replaceChildren(...Array.from(scratch.childNodes));
+      this.errorEl.hidden = true;
+    } else {
+      this.errorTextEl.textContent = result.error;
+      this.errorEl.hidden = false;
+    }
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/unit/renderer/components/PreviewableSourceEditor.test.ts`
+Expected: PASS (12 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/components/PreviewableSourceEditor.ts tests/unit/renderer/components/PreviewableSourceEditor.test.ts
+git commit -m "feat: PreviewableSourceEditor surfaces render errors via inline chip"
+```
+
+---
+
+## Task 11: `PreviewableSourceEditor` — Esc commits
+
+**Files:**
+- Modify: `src/renderer/components/PreviewableSourceEditor.ts`
+- Test: `tests/unit/renderer/components/PreviewableSourceEditor.test.ts`
+
+- [ ] **Step 1: Write the failing test (append)**
+
+```ts
+describe('PreviewableSourceEditor Esc', () => {
+  it('Escape on the textarea commits the session', () => {
+    const el = contentEl('<div class="mermaid-container"></div>');
+    const onCommit = vi.fn();
+    const editor = new PreviewableSourceEditor(el, slice(), fakePlugin(), { onCommit });
+    editor.start();
+    const ta = el.querySelector<HTMLTextAreaElement>('textarea')!;
+    ta.value = 'C --> D';
+    ta.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+    expect(onCommit).toHaveBeenCalledWith('```mermaid\nC --> D\n```');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/renderer/components/PreviewableSourceEditor.test.ts`
+Expected: FAIL — no keydown listener wired.
+
+- [ ] **Step 3: Add the implementation**
+
+Extend `start()` to add the keydown listener (after the input listener):
+
+```ts
+    this.textarea.addEventListener('keydown', this.onKeyDown);
+```
+
+Extend `commit()` to remove the listener (where the input listener is removed):
+
+```ts
+    this.textarea.removeEventListener('input', this.onInput);
+    this.textarea.removeEventListener('keydown', this.onKeyDown);
+```
+
+Add the handler:
+
+```ts
+  private readonly onKeyDown = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      this.commit();
+    }
+  };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/unit/renderer/components/PreviewableSourceEditor.test.ts`
+Expected: PASS (13 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/components/PreviewableSourceEditor.ts tests/unit/renderer/components/PreviewableSourceEditor.test.ts
+git commit -m "feat: PreviewableSourceEditor commits on Esc"
+```
+
+---
+
+## Task 12: `EditModeController` — route mermaid slices to the previewable editor
+
+**Files:**
+- Modify: `src/renderer/components/EditModeController.ts`
+- Test: `tests/unit/renderer/components/EditModeController.test.ts`
+
+This task adds the routing and the controller-side commit dispatch. It also factors the existing `commitRawEdit`'s re-render path into a shared helper so the previewable commit can reuse it.
+
+- [ ] **Step 1: Write the failing test (append a new describe block)**
+
+```ts
+// Place near the other describes in EditModeController.test.ts. Reuse the
+// existing setup() and makePluginManager() helpers; extend the stub plugin
+// manager with previewable support.
+
+import type { PreviewablePlugin } from '../../../../src/plugins/types/preview';
+
+function makePreviewableManager(): PluginManager {
+  const pm = makePluginManager() as unknown as PluginManager & {
+    getPreviewablePlugins: () => (PreviewablePlugin & { metadata: unknown })[];
+  };
+  pm.getPreviewablePlugins = () => [{
+    metadata: { id: 'mermaid', name: 'mermaid', version: '1.0.0', description: '' },
+    matchesSlice: (s) => s.type === 'code' && /^```mermaid\b/.test(s.raw.trimStart()),
+    extractSource: (s) => {
+      const lines = s.raw.split('\n');
+      return lines.slice(1, -1).join('\n');
+    },
+    renderPreview: async () => ({ ok: true }),
+    applySourceToRaw: (_s, source) => '```mermaid\n' + source + '\n```',
+  } as unknown as PreviewablePlugin & { metadata: unknown }];
+  return pm;
+}
+
+function setupPreviewable(): { container: HTMLElement; controller: EditModeController } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const controller = new EditModeController(container, makePreviewableManager());
+  return { container, controller };
+}
+
+describe('EditModeController — previewable mermaid editing', () => {
+  it('clicking a ```mermaid slice opens the PreviewableSourceEditor (preview + textarea coexist)', async () => {
+    const { container, controller } = setupPreviewable();
+    await controller.enter('```mermaid\nA --> B\n```');
+    const content = container.querySelector<HTMLElement>('.slice-content')!;
+    content.click();
+    expect(content.querySelector('.preview-source-preview')).not.toBe(null);
+    expect(content.querySelector('textarea.slice-raw-editor')).not.toBe(null);
+    expect(content.querySelector<HTMLTextAreaElement>('textarea')!.value).toBe('A --> B');
+  });
+
+  it('clicking a non-mermaid code slice still opens the regular raw editor (no preview area)', async () => {
+    const { container, controller } = setupPreviewable();
+    await controller.enter('```js\nconsole.log(1);\n```');
+    const content = container.querySelector<HTMLElement>('.slice-content')!;
+    content.click();
+    expect(content.querySelector('.preview-source-preview')).toBe(null);
+    expect(content.querySelector('textarea.slice-raw-editor')).not.toBe(null);
+  });
+
+  it('clicking a paragraph still opens the WYSIWYG inline editor', async () => {
+    const { container, controller } = setupPreviewable();
+    await controller.enter('Hello world');
+    const content = container.querySelector<HTMLElement>('.slice-content')!;
+    content.click();
+    expect(content.getAttribute('contenteditable')).toBe('true');
+    expect(content.querySelector('.preview-source-preview')).toBe(null);
+  });
+
+  it('committing a previewable edit updates the slice raw with the new fenced content', async () => {
+    const { container, controller } = setupPreviewable();
+    const onContentChange = vi.fn();
+    controller.setCallbacks({ onContentChange });
+    await controller.enter('```mermaid\nA --> B\n```');
+    container.querySelector<HTMLElement>('.slice-content')!.click();
+    const ta = container.querySelector<HTMLTextAreaElement>('textarea.slice-raw-editor')!;
+    ta.value = 'C --> D';
+    controller.commitActiveEditForTest();
+    expect(controller.getMarkdown()).toBe('```mermaid\nC --> D\n```');
+    expect(onContentChange).toHaveBeenCalledWith('```mermaid\nC --> D\n```');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/renderer/components/EditModeController.test.ts`
+Expected: FAIL — mermaid slice currently routes to canSerialize fallback (raw editor without preview area).
+
+- [ ] **Step 3: Modify the controller — add imports, fields, route, commit dispatch, shared helper**
+
+Add imports at the top of `src/renderer/components/EditModeController.ts`:
+
+```ts
+import { PreviewableSourceEditor } from './PreviewableSourceEditor';
+import type { PreviewablePlugin } from '../../plugins/types/preview';
+```
+
+Add a field next to `activeInlineEditor` and `activeRawTextarea`:
+
+```ts
+  private activePreviewableEditor: PreviewableSourceEditor | null = null;
+```
+
+Replace the body of `startEdit` so the previewable branch runs BEFORE the existing canSerialize / WYSIWYG routing:
+
+```ts
+  private startEdit(sliceIndex: number): void {
+    this.commitActiveEdit();
+
+    const slice = this.slices.find((s) => s.index === sliceIndex);
+    const el = this.sliceElements.get(sliceIndex);
+    if (!slice || !el) return;
+
+    const contentEl = el.querySelector<HTMLElement>('.slice-content');
+    if (!contentEl) return;
+
+    // Previewable plugin opt-in (e.g. mermaid live preview).
+    const previewable = this.findPreviewablePluginFor(slice);
+    if (previewable) {
+      this.activeEditIndex = sliceIndex;
+      el.classList.add('slice-editing');
+      this.activePreviewableEditor = new PreviewableSourceEditor(
+        contentEl, slice, previewable,
+        { onCommit: (newRaw) => this.applyRawCommit(sliceIndex, newRaw) },
+      );
+      this.activePreviewableEditor.start();
+      return;
+    }
+
+    // Unsupported inline content (or block types canSerialize rejects) → raw editor.
+    if (!canSerialize(contentEl)) {
+      this.startRawEdit(sliceIndex);
+      return;
+    }
+
+    this.activeEditIndex = sliceIndex;
+    el.classList.add('slice-editing');
+
+    this.activeInlineEditor = new InlineEditor(contentEl, {
+      onCommit: (inlineMarkdown) => {
+        this.applyInlineCommit(sliceIndex, inlineMarkdown);
+      },
+      onRequestLink: () => {
+        if (this.activeInlineEditor) this.promptAndApplyLink(this.activeInlineEditor);
+      },
+      onSplit: (beforeMd, afterMd) => {
+        this.splitActiveSlice(sliceIndex, beforeMd, afterMd);
+      },
+      onNavigate: (direction) => {
+        this.navigateFromSlice(sliceIndex, direction);
+      },
+    });
+    this.activeInlineEditor.start();
+    if (this.toolbarVisible) {
+      this.getToolbar().show(contentEl);
+      this.refreshToolbarState();
+    }
+  }
+```
+
+Add the lookup helper:
+
+```ts
+  private findPreviewablePluginFor(slice: MarkdownSlice): PreviewablePlugin | null {
+    const pm = this.pluginManager as PluginManager & {
+      getPreviewablePlugins?: () => (PreviewablePlugin & { metadata: unknown })[];
+    };
+    if (typeof pm.getPreviewablePlugins !== 'function') return null;
+    for (const plugin of pm.getPreviewablePlugins()) {
+      if (plugin.matchesSlice(slice)) return plugin;
+    }
+    return null;
+  }
+```
+
+Update `commitActiveEdit` to dispatch to the previewable editor first:
+
+```ts
+  private commitActiveEdit(): void {
+    if (this.activeEditIndex === null) return;
+    const sliceIndex = this.activeEditIndex;
+    this.activeEditIndex = null;
+
+    if (this.activePreviewableEditor) {
+      const editor = this.activePreviewableEditor;
+      this.activePreviewableEditor = null;
+      editor.commit();
+      return;
+    }
+    if (this.activeRawTextarea) {
+      this.commitRawEdit(sliceIndex);
+      return;
+    }
+    const editor = this.activeInlineEditor;
+    this.activeInlineEditor = null;
+    this.toolbar?.hide();
+    editor?.commit();
+  }
+```
+
+Factor the existing post-update re-render logic out of `commitRawEdit` into a shared helper. Locate the existing `commitRawEdit` method; replace its body with a call to the new helper:
+
+```ts
+  private commitRawEdit(sliceIndex: number): void {
+    const textarea = this.activeRawTextarea;
+    this.activeRawTextarea = null;
+    if (!textarea) return;
+    this.applyRawCommit(sliceIndex, textarea.value);
+  }
+
+  /**
+   * Shared "raw commit" path used by both the slim raw textarea and the
+   * PreviewableSourceEditor. Updates the slice via the slicer, fires
+   * onContentChange, and re-renders the slice.
+   */
+  private applyRawCommit(sliceIndex: number, newRaw: string): void {
+    const slice = this.slices.find((s) => s.index === sliceIndex);
+    const el = this.sliceElements.get(sliceIndex);
+    if (!slice || !el) return;
+
+    if (newRaw !== slice.raw) {
+      const result = this.slicer.updateSlice(this.slices, sliceIndex, newRaw);
+      this.rawMarkdown = result.markdown;
+      this.slices = result.slices;
+      this.callbacks.onContentChange?.(this.rawMarkdown);
+    }
+
+    el.classList.remove('slice-editing');
+    const contentEl = el.querySelector('.slice-content');
+    const updatedSlice = this.slices.find((s) => s.index === sliceIndex);
+    if (contentEl) {
+      const html = this.pluginManager.render(updatedSlice?.raw ?? slice.raw);
+      contentEl.replaceChildren();
+      contentEl.insertAdjacentHTML('afterbegin', html);
+      contentEl.addEventListener('click', (e) => {
+        if ((e.target as HTMLElement).closest('a')) return;
+        e.stopPropagation();
+        this.startEdit(sliceIndex);
+      });
+      void this.pluginManager.postRender(contentEl as HTMLElement);
+    }
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/unit/renderer/components/EditModeController.test.ts`
+Expected: PASS — all suites green, including the four new previewable tests.
+
+- [ ] **Step 5: Run the full suite to catch regressions**
+
+Run: `pnpm test`
+Expected: PASS — all suites green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/components/EditModeController.ts tests/unit/renderer/components/EditModeController.test.ts
+git commit -m "feat: route mermaid slices to PreviewableSourceEditor"
+```
+
+---
+
+## Task 13: Styling for preview area + error chip
+
+**Files:**
+- Modify: `src/index.css`
+
+No automated test — visual styling, verified manually in Task 14.
+
+- [ ] **Step 1: Append the new rules**
+
+Locate the existing `.slice-content[contenteditable='true']` rule (it sits below `.slice.slice-editing .slice-content::before`). Append the following block after the existing slice-content rules and before the next section comment:
+
+```css
+/* Live-preview editor: preview area + error chip + textarea. */
+.preview-source-preview {
+  /* The preview's natural sizing is whatever the plugin renders (mermaid SVG
+   * is `max-width: 100%; height: auto;`). No extra constraints. */
+}
+
+.preview-source-error {
+  margin: 4px 0 0;
+  padding: 6px 10px;
+  border-radius: 4px;
+  background: var(--error-bg, rgba(220, 38, 38, 0.12));
+  color: var(--error-text, #b91c1c);
+  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+  font-size: 12px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.preview-source-error[hidden] {
+  display: none;
+}
+
+.preview-source-preview + .preview-source-error + .slice-raw-editor,
+.preview-source-preview + .slice-raw-editor {
+  /* Small gap between preview/error and the editor textarea. */
+  margin-top: 6px;
+}
+```
+
+- [ ] **Step 2: Verify no `.ts` regressions**
+
+Run: `pnpm typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/index.css
+git commit -m "style: live-preview editor area and error chip"
+```
+
+---
+
+## Task 14: Integration verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full type check**
+
+Run: `pnpm typecheck`
+Expected: PASS — no errors.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `pnpm test`
+Expected: PASS — all suites green, including the new MermaidPlugin / PreviewableSourceEditor / EditModeController suites.
+
+- [ ] **Step 3: Lint**
+
+Run: `pnpm lint`
+Expected: PASS. Fix any issues (typical culprits: unused imports, missing types on closures).
+
+- [ ] **Step 4: Manual smoke check**
+
+Run: `pnpm start`
+
+Open a markdown file containing a mermaid diagram (e.g. `site/examples/water-cycle-and-chemistry.md`). Then:
+
+- Enter edit mode (`Cmd+E`). Confirm the mermaid diagram renders.
+- Click the mermaid block. Confirm:
+  - The diagram stays visible above
+  - A textarea appears below with the diagram source (no opening/closing fences)
+- Type into the textarea. Confirm:
+  - The diagram refreshes ~250ms after you stop typing
+  - The previous good diagram stays during invalid intermediate states
+- Type something that's clearly invalid (e.g. `graph TX`). Confirm:
+  - The last good diagram remains visible
+  - A red error chip appears between the diagram and the textarea with the mermaid error message
+- Correct the source. Confirm the error chip disappears and the diagram updates.
+- Press `Esc`. Confirm:
+  - The diagram re-renders with the new source
+  - The textarea is gone
+- Click a non-mermaid code block (`` ```js ``). Confirm it opens the regular slim raw textarea (no preview area).
+- Click a paragraph. Confirm it still opens the WYSIWYG inline editor.
+
+- [ ] **Step 5: Final commit (only if Step 3 required lint fixes)**
+
+```bash
+git add -A
+git commit -m "chore: lint fixes for live mermaid preview"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** plugin contract (Task 1) — declared in dedicated types file; PluginManager surface (Task 2); mermaid implementation (Tasks 3-6); editor component (Tasks 7-11) covering lifecycle, debounced render, race control, error chip, Esc-commit; controller integration (Task 12) including factored `applyRawCommit` so both raw paths share the same re-render code; styling (Task 13); manual smoke for the cases in the spec's data-flow + error matrix (Task 14).
+- **Known design follow-up:** the spec calls out that the live render's output may not preserve the `.mermaid-container` wrapper styles. The implementation uses a scratch container (Task 9) so the live render's output is whatever the plugin emits. If mermaid emits raw `<svg>` without the wrapper, mermaid-container-specific CSS (centring, overflow-x) won't apply during the edit session. This is acceptable: the live diagram is bounded by the slice width via SVG `max-width: 100%`. If it looks off in manual smoke, fix as a follow-up by wrapping the scratch contents in `<div class="mermaid-container">` inside `MermaidPlugin.renderPreview`.
+- **Type consistency:** `PreviewablePlugin` (`src/plugins/types/preview.ts`) is the single source of truth; both `PluginManager.getPreviewablePlugins` and `EditModeController.findPreviewablePluginFor` use the same type. `PreviewableSourceEditor` callbacks (`onCommit: (newRaw: string) => void`) match how `applyRawCommit` is invoked from the controller. `MermaidPlugin` declares `implements MarkdownPlugin, PreviewablePlugin`, and Task 3 introduces stub throws so the type-check remains green between subtasks.
+- **DOM construction:** no raw HTML-string assignment in any new code — `replaceChildren()` + `insertAdjacentHTML('afterbegin', …)` everywhere, matching the existing slice-menu and slice-content commit code in `EditModeController`.

--- a/docs/superpowers/specs/2026-05-19-mermaid-live-preview-design.md
+++ b/docs/superpowers/specs/2026-05-19-mermaid-live-preview-design.md
@@ -1,0 +1,340 @@
+# Live Mermaid Preview While Editing — Design
+
+**Date:** 2026-05-19
+**Status:** Approved
+
+## Problem
+
+Editing a mermaid diagram in edit mode currently means clicking the slice and
+seeing the slim raw-markdown textarea — the rendered diagram disappears. The
+user types blind, commits, and only then sees whether the change worked. For
+visual diagrams this is the wrong feedback loop.
+
+## Goal
+
+While the user is editing a mermaid block, show the rendered diagram **above**
+the source so changes are reflected in near-realtime as they type. Keep the
+last successful render visible whenever the source is mid-edit and invalid; a
+small inline error chip surfaces the syntax problem without removing the
+diagram.
+
+Design the feature so it generalises: any plugin that can render a fenced
+code block to visual content can opt into the same live-preview surface.
+
+## Approach
+
+Introduce a generic plugin capability — `PreviewablePlugin` — and a single
+new component, `PreviewableSourceEditor`, that drives editing sessions for
+slices owned by such plugins. `EditModeController` gains one new branch in
+`startEdit`: if any previewable plugin matches the slice, open
+`PreviewableSourceEditor` instead of the existing WYSIWYG-or-raw routing.
+
+The mermaid plugin is the first implementer. Future plugins (math, graphviz,
+embedded HTML, etc.) get live-preview for free by implementing the same four
+methods.
+
+Rejected alternatives:
+
+- **Special-case mermaid in `EditModeController` directly.** Cheaper to ship
+  but no abstraction for future plugins. We have one such plugin today;
+  rather than add the second one before the contract exists, we accept the
+  modest extra design surface up front.
+- **Dedicated mermaid editor modal / split view.** Too big a departure from
+  the inline-edit flow; complicates focus, escape semantics, and slice-state
+  bookkeeping.
+
+## Components
+
+### New
+
+| Component | Responsibility | Location |
+|---|---|---|
+| `PreviewablePlugin` interface | Optional plugin capability. Declares `matchesSlice`, `extractSource`, `renderPreview`, `applySourceToRaw`. | `src/plugins/types/preview.ts` |
+| `PreviewableSourceEditor` | One editing session. Owns the layout (preview top, error chip middle, textarea bottom), the debounced re-render, the error-chip toggling, the idempotent commit. | `src/renderer/components/` |
+
+### Modified
+
+- **`MermaidPlugin`** — implements `PreviewablePlugin`. Adds four methods.
+  Existing `apply` (fence override) and `postRender` (async render) paths are
+  unchanged; live preview is additive.
+- **`EditModeController`** — adds `findPreviewablePluginFor(slice)` lookup
+  and one new branch at the top of `startEdit`. Also factors the existing
+  `commitRawEdit` logic into a shared `applyRawCommit` helper so both raw
+  paths (slim textarea, previewable editor) share the same slice-update +
+  re-render code.
+- **`PluginManager`** — adds `getPreviewablePlugins()` returning the subset
+  of plugins that implement the optional capability (type-narrowed).
+- **`index.css`** — styles for the preview area, error chip, and the
+  textarea-below-preview layout.
+
+## The plugin contract
+
+```ts
+export interface PreviewablePlugin {
+  /** Does this plugin own the given slice? Fast and side-effect-free. */
+  matchesSlice(slice: MarkdownSlice): boolean;
+
+  /** Extract the user-editable source from the slice's raw markdown
+   *  (e.g. strip ```mermaid fences). */
+  extractSource(slice: MarkdownSlice): string;
+
+  /** Render `source` into `target`, replacing its contents on success.
+   *  MUST NOT throw — errors are returned so the caller can keep the
+   *  previous good preview visible. */
+  renderPreview(
+    source: string,
+    target: HTMLElement
+  ): Promise<{ ok: true } | { ok: false; error: string }>;
+
+  /** Inverse of extractSource — wrap the edited source back into a full
+   *  slice raw. Implementations may consult `slice.raw` to preserve
+   *  details like a fence's info-string. */
+  applySourceToRaw(slice: MarkdownSlice, source: string): string;
+}
+```
+
+Key contract guarantees:
+
+- `renderPreview` never throws. The `{ ok, error }` shape lets the editor
+  keep the last good preview while showing an error chip.
+- On `{ ok: true }`, `target`'s contents are replaced. On `{ ok: false }`,
+  `target` is left alone. The caller can rely on "new content = render
+  succeeded."
+- The four methods are stateless on the plugin (matches/extract/apply are
+  pure; renderPreview is async + mutates the target). All session state
+  lives in `PreviewableSourceEditor`.
+
+## `PreviewableSourceEditor`
+
+### Public API
+
+```ts
+export interface PreviewableSourceEditorCallbacks {
+  /** Called once when the session commits, with the new slice raw. */
+  onCommit: (newRaw: string) => void;
+}
+
+export class PreviewableSourceEditor {
+  constructor(
+    contentEl: HTMLElement,
+    slice: MarkdownSlice,
+    plugin: PreviewablePlugin,
+    callbacks: PreviewableSourceEditorCallbacks
+  );
+  start(): void;
+  commit(): void; // idempotent
+}
+```
+
+### DOM it builds inside `contentEl`
+
+```
+<div class="slice-content">                  ← passed-in contentEl
+  <div class="preview-source-preview">       ← preview area (top)
+    <!-- existing rendered SVG stays here -->
+  </div>
+  <div class="preview-source-error" hidden>  ← error chip (between)
+    <span class="preview-source-error-text"></span>
+  </div>
+  <textarea class="slice-raw-editor">        ← editor (bottom)
+    initial value = plugin.extractSource(slice)
+  </textarea>
+</div>
+```
+
+The preview area uses the **existing rendered SVG** as its starting state —
+when `start()` runs, the slice-content already contains the
+`<div.mermaid-container>` placeholder filled with SVG. The editor wraps it in
+the new structure rather than re-rendering.
+
+### Behavior
+
+- **Initial:** existing preview visible, textarea focused, error chip hidden.
+- **Typing:** debounce 250ms after the last keystroke → call
+  `plugin.renderPreview(textarea.value, previewArea)`.
+- **On success:** preview area's contents are replaced. Error chip stays
+  hidden.
+- **On error:** preview area is unchanged. Error chip becomes visible with
+  the error text.
+- **Race control:** each `renderPreview` call carries a monotonic
+  `requestId`. When the promise resolves, the result is dropped if a newer
+  call has been issued in between. Last keystroke wins.
+- **`Esc`, blur, click-away:** committed via `commit()`.
+- **`commit()`** runs `plugin.applySourceToRaw(slice, textarea.value)` →
+  `callbacks.onCommit(newRaw)`. Cancels any pending debounced render before
+  committing. Idempotent (boolean flag).
+
+## MermaidPlugin implementation
+
+```ts
+matchesSlice(slice: MarkdownSlice): boolean {
+  if (slice.type !== 'code') return false;
+  const firstLine = slice.raw.trimStart().split('\n', 1)[0] ?? '';
+  return /^```mermaid\b/.test(firstLine);
+}
+
+extractSource(slice: MarkdownSlice): string {
+  const lines = slice.raw.split('\n');
+  let start = 0;
+  let end = lines.length;
+  if (lines[0]?.trimStart().startsWith('```mermaid')) start = 1;
+  if (lines[lines.length - 1]?.trim() === '```') end = lines.length - 1;
+  return lines.slice(start, end).join('\n');
+}
+
+async renderPreview(
+  source: string,
+  target: HTMLElement
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (!this.mermaid) return { ok: false, error: 'Mermaid not initialised' };
+  try {
+    const id = `mermaid-preview-${this.diagramCounter++}`;
+    const { svg } = await this.mermaid.render(id, source);
+    target.replaceChildren();
+    target.insertAdjacentHTML('afterbegin', svg);
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+applySourceToRaw(slice: MarkdownSlice, source: string): string {
+  const firstLine = slice.raw.trimStart().split('\n', 1)[0] ?? '';
+  const match = firstLine.match(/^```(.*)$/);
+  const info = match?.[1] ?? 'mermaid';
+  return '```' + info + '\n' + source + '\n```';
+}
+```
+
+Notes:
+
+- `matchesSlice` is conservative: only fenced code blocks whose info-string
+  starts with `mermaid`. `` ```js ``, `` ```python `` etc. fall through to
+  the existing raw editor.
+- `applySourceToRaw` recovers the original info-string from `slice.raw`'s
+  opening fence. This preserves details like `` ```mermaid theme=dark ``.
+  Falls back to `mermaid` if the original fence doesn't parse.
+- `renderPreview` reuses the plugin's `diagramCounter` so live and
+  post-render ids never collide.
+- The existing `postRender` path is unchanged. Live preview is purely
+  additive.
+
+## Controller wiring
+
+```ts
+// In EditModeController.startEdit, BEFORE the canSerialize check:
+const previewable = this.findPreviewablePluginFor(slice);
+if (previewable) {
+  this.activeEditIndex = sliceIndex;
+  el.classList.add('slice-editing');
+  this.activePreviewableEditor = new PreviewableSourceEditor(
+    contentEl, slice, previewable,
+    { onCommit: (newRaw) => this.applyRawCommit(sliceIndex, newRaw) }
+  );
+  this.activePreviewableEditor.start();
+  return;
+}
+// existing canSerialize / WYSIWYG / raw routing follows
+```
+
+`commitActiveEdit` learns one more branch: route to
+`this.activePreviewableEditor.commit()` if it's set.
+
+`applyRawCommit(sliceIndex, newRaw)` is the existing `commitRawEdit` body
+factored out so both the slim raw editor and the previewable editor share
+the same slice-update + re-render path.
+
+## Data flow
+
+```
+Open
+  click mermaid slice
+    → startEdit
+      → findPreviewablePluginFor → MermaidPlugin
+      → new PreviewableSourceEditor(contentEl, slice, plugin, callbacks)
+      → editor.start()
+        → wrap contentEl: [preview][error hidden][textarea]
+        → textarea.value = plugin.extractSource(slice)
+        → textarea.focus()
+
+Type
+  textarea input → debounce 250ms
+    → requestId = ++renderCounter
+    → plugin.renderPreview(source, previewArea)
+      → { ok: true } & latest: preview replaced, error chip hidden
+      → { ok: false } & latest: preview untouched, error chip shown
+      → stale: result discarded
+
+Commit (Esc / blur / segment switch)
+  editor.commit()
+    → cancel pending debounce
+    → newRaw = plugin.applySourceToRaw(slice, textarea.value)
+    → callbacks.onCommit(newRaw)
+      → controller.applyRawCommit(sliceIndex, newRaw)
+        → slicer.updateSlice → rawMarkdown, slices updated
+        → callbacks.onContentChange(rawMarkdown)
+        → re-render slice via standard path (postRender re-renders mermaid)
+```
+
+## Error handling
+
+| Situation | Behavior |
+|---|---|
+| Mermaid library not initialised | `{ ok: false, error: 'Mermaid not initialised' }`. Error chip; preview unchanged (likely empty on first render). Practically unreachable. |
+| Mermaid syntax error | `{ ok: false, error: <mermaid's message> }`. Error chip shows the message; last good preview stays. |
+| `renderPreview` throws unexpectedly | Caught and converted to `{ ok: false }`. Contract: never throws. |
+| Concurrent renders | Monotonic `requestId` discards stale results. Last keystroke wins. |
+| Commit before debounce fires | Pending render is cancelled. Commit uses the textarea's current value. |
+| User presses `Esc` over an invalid source | Slice is committed with whatever's in the textarea — invalid mermaid round-trips back as a slice that the post-render path will mark as a `<div.mermaid-error>`. Matches existing behavior for raw commits. |
+
+The last good preview is sticky for the entire edit session. The error chip
+makes invalid state visible without losing context.
+
+## Testing
+
+- **`MermaidPlugin.test.ts`** — extend with:
+  - `matchesSlice` truth table (mermaid, mermaid-with-info-string, other
+    languages, non-code slices, missing fence).
+  - `extractSource` strips fences and preserves inner content verbatim incl.
+    blank lines.
+  - `applySourceToRaw` round-trips `` ```mermaid `` and `` ```mermaid info ``;
+    falls back to `mermaid` when slice.raw has no recognisable fence.
+  - `renderPreview` success path (target replaced; `{ ok: true }`), failure
+    path (target untouched; `{ ok: false, error }`), and uninitialised path.
+    Mocks the mermaid library.
+
+- **`PreviewableSourceEditor.test.ts`** (new) — jsdom:
+  - `start()` builds the expected DOM and focuses the textarea.
+  - Initial textarea value equals `plugin.extractSource(slice)`.
+  - Typing triggers a debounced `renderPreview` call (`vi.useFakeTimers`).
+  - `{ ok: true }` replaces preview; error chip stays hidden.
+  - `{ ok: false }` leaves preview alone; error chip becomes visible.
+  - Concurrent renders: a slow first call followed by a fast second call —
+    only the second result is applied.
+  - `commit()` calls `applySourceToRaw` and forwards to `onCommit`.
+  - `commit()` is idempotent.
+  - `Esc` on the textarea commits.
+
+- **`EditModeController.test.ts`** — extend with:
+  - Clicking a `` ```mermaid `` slice opens the previewable editor (assert
+    via DOM: preview + textarea coexist).
+  - Clicking a `` ```js `` slice opens the regular raw textarea (no preview
+    area).
+  - Clicking a paragraph still opens the WYSIWYG inline editor.
+  - Committing a previewable edit updates the slice raw with the new fenced
+    content; `onContentChange` fires.
+
+Tests use a `FakePreviewablePlugin` stub so the controller test doesn't
+depend on the real mermaid library.
+
+## Out of scope
+
+- Editing other code-block languages with live preview (e.g. live HTML
+  rendering, math). The contract supports it; implementation is per-plugin
+  and lands separately when a second consumer exists.
+- Syntax highlighting inside the textarea (CodeMirror or similar). The
+  existing `.slice-raw-editor` plain textarea is reused.
+- A `Cmd+/` toggle to expand/collapse the preview area. Defer until users
+  ask.
+- Slice handle alignment for mermaid blocks (the separate reported issue).
+  Handled as a small follow-up CSS tweak independent of this design.

--- a/src/index.css
+++ b/src/index.css
@@ -1814,6 +1814,35 @@ button:focus:not(:focus-visible) {
   cursor: text;
 }
 
+/* Live-preview editor: preview area + error chip + textarea. */
+.preview-source-preview {
+  /* The preview's natural sizing is whatever the plugin renders (mermaid SVG
+   * is `max-width: 100%; height: auto;`). No extra constraints. */
+}
+
+.preview-source-error {
+  margin: 4px 0 0;
+  padding: 6px 10px;
+  border-radius: 4px;
+  background: var(--error-bg, rgba(220, 38, 38, 0.12));
+  color: var(--error-text, #b91c1c);
+  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+  font-size: 12px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.preview-source-error[hidden] {
+  display: none;
+}
+
+.preview-source-preview + .preview-source-error + .slice-raw-editor,
+.preview-source-preview + .slice-raw-editor {
+  /* Small gap between preview/error and the editor textarea. */
+  margin-top: 6px;
+}
+
 /* Slim raw-markdown editor (used by the "Edit as markdown" toggle) */
 .slice-raw-editor {
   width: 100%;

--- a/src/index.css
+++ b/src/index.css
@@ -1751,6 +1751,10 @@ button:focus:not(:focus-visible) {
 .slice-h5 { --slice-handle-top: 20px; } /* 0.875em * 1.25 = 15.3, center y=31.65 */
 .slice-h6 { --slice-handle-top: 19px; } /* 0.85em * 1.25 = 14.9, center y=31.45 */
 .slice-code { --slice-handle-top: 13px; } /* <pre> padding-top 16 + 85% * 1.45 ≈ 17, center y=24.5 */
+/* Mermaid blocks share the 'code' slice type but render as <div.mermaid-container>
+ * (no <pre>, no padding). Their content starts flush with the slice top, so the
+ * 13px offset tuned for <pre> would push the handle into the diagram. */
+.slice-code:has(.mermaid-container) { --slice-handle-top: 0px; }
 
 .slice-handle-btn {
   display: flex;

--- a/src/index.css
+++ b/src/index.css
@@ -1815,11 +1815,8 @@ button:focus:not(:focus-visible) {
 }
 
 /* Live-preview editor: preview area + error chip + textarea. */
-.preview-source-preview {
-  /* The preview's natural sizing is whatever the plugin renders (mermaid SVG
-   * is `max-width: 100%; height: auto;`). No extra constraints. */
-}
-
+/* .preview-source-preview has no rules: the preview's natural sizing is
+ * whatever the plugin renders (mermaid SVG is `max-width: 100%; height: auto;`). */
 .preview-source-error {
   margin: 4px 0 0;
   padding: 6px 10px;

--- a/src/plugins/builtin/MermaidPlugin.ts
+++ b/src/plugins/builtin/MermaidPlugin.ts
@@ -608,8 +608,20 @@ export class MermaidPlugin implements MarkdownPlugin, PreviewablePlugin {
     return /^(?:```|~~~)mermaid\b/.test(firstLine);
   }
 
-  extractSource(_slice: MarkdownSlice): string {
-    throw new Error('not implemented');
+  extractSource(slice: MarkdownSlice): string {
+    const lines = slice.raw.split('\n');
+    let start = 0;
+    let end = lines.length;
+    // Strip opening fence (``` or ~~~ followed by "mermaid").
+    if (lines[0] && /^(?:```|~~~)mermaid\b/.test(lines[0].trimStart())) {
+      start = 1;
+    }
+    // Strip closing fence (``` or ~~~ on its own).
+    const lastLine = lines[lines.length - 1]?.trim();
+    if (lastLine === '```' || lastLine === '~~~') {
+      end = lines.length - 1;
+    }
+    return lines.slice(start, end).join('\n');
   }
 
   async renderPreview(

--- a/src/plugins/builtin/MermaidPlugin.ts
+++ b/src/plugins/builtin/MermaidPlugin.ts
@@ -605,7 +605,7 @@ export class MermaidPlugin implements MarkdownPlugin, PreviewablePlugin {
   matchesSlice(slice: MarkdownSlice): boolean {
     if (slice.type !== 'code') return false;
     const firstLine = slice.raw.trimStart().split('\n', 1)[0] ?? '';
-    return /^```mermaid\b/.test(firstLine);
+    return /^(?:```|~~~)mermaid\b/.test(firstLine);
   }
 
   extractSource(_slice: MarkdownSlice): string {

--- a/src/plugins/builtin/MermaidPlugin.ts
+++ b/src/plugins/builtin/MermaidPlugin.ts
@@ -631,8 +631,12 @@ export class MermaidPlugin implements MarkdownPlugin, PreviewablePlugin {
     throw new Error('not implemented');
   }
 
-  applySourceToRaw(_slice: MarkdownSlice, _source: string): string {
-    throw new Error('not implemented');
+  applySourceToRaw(slice: MarkdownSlice, source: string): string {
+    const firstLine = slice.raw.trimStart().split('\n', 1)[0] ?? '';
+    const match = firstLine.match(/^(```|~~~)(.*)$/);
+    const fence = match?.[1] ?? '```';
+    const info = match?.[2] ?? 'mermaid';
+    return fence + info + '\n' + source + '\n' + fence;
   }
 
   destroy(): void {

--- a/src/plugins/builtin/MermaidPlugin.ts
+++ b/src/plugins/builtin/MermaidPlugin.ts
@@ -625,10 +625,19 @@ export class MermaidPlugin implements MarkdownPlugin, PreviewablePlugin {
   }
 
   async renderPreview(
-    _source: string,
-    _target: HTMLElement,
+    source: string,
+    target: HTMLElement,
   ): Promise<{ ok: true } | { ok: false; error: string }> {
-    throw new Error('not implemented');
+    if (!this.mermaid) return { ok: false, error: 'Mermaid not initialised' };
+    try {
+      const id = `mermaid-preview-${this.diagramCounter++}`;
+      const { svg } = await this.mermaid.render(id, source);
+      target.replaceChildren();
+      target.insertAdjacentHTML('afterbegin', svg);
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : String(e) };
+    }
   }
 
   applySourceToRaw(slice: MarkdownSlice, source: string): string {

--- a/src/plugins/builtin/MermaidPlugin.ts
+++ b/src/plugins/builtin/MermaidPlugin.ts
@@ -20,6 +20,8 @@ import type {
 } from '@shared/types';
 import type { PluginThemeDeclaration } from '../../themes/types';
 import type MarkdownIt from 'markdown-it';
+import type { PreviewablePlugin } from '../types/preview';
+import type { MarkdownSlice } from '../../renderer/services/MarkdownSlicer';
 
 /**
  * Options for the MermaidPlugin
@@ -34,7 +36,7 @@ export interface MermaidOptions extends PluginOptions {
 /**
  * Mermaid diagram rendering plugin
  */
-export class MermaidPlugin implements MarkdownPlugin {
+export class MermaidPlugin implements MarkdownPlugin, PreviewablePlugin {
   metadata: PluginMetadata = {
     id: BUILTIN_PLUGINS.MERMAID,
     name: 'Mermaid Diagrams',
@@ -598,6 +600,27 @@ export class MermaidPlugin implements MarkdownPlugin {
     const base64 = btoa(String.fromCharCode(...compressed));
 
     return `https://mermaid.live/edit#pako:${base64}`;
+  }
+
+  matchesSlice(slice: MarkdownSlice): boolean {
+    if (slice.type !== 'code') return false;
+    const firstLine = slice.raw.trimStart().split('\n', 1)[0] ?? '';
+    return /^```mermaid\b/.test(firstLine);
+  }
+
+  extractSource(_slice: MarkdownSlice): string {
+    throw new Error('not implemented');
+  }
+
+  async renderPreview(
+    _source: string,
+    _target: HTMLElement,
+  ): Promise<{ ok: true } | { ok: false; error: string }> {
+    throw new Error('not implemented');
+  }
+
+  applySourceToRaw(_slice: MarkdownSlice, _source: string): string {
+    throw new Error('not implemented');
   }
 
   destroy(): void {

--- a/src/plugins/builtin/MermaidPlugin.ts
+++ b/src/plugins/builtin/MermaidPlugin.ts
@@ -617,7 +617,7 @@ export class MermaidPlugin implements MarkdownPlugin, PreviewablePlugin {
       start = 1;
     }
     // Strip closing fence (``` or ~~~ on its own).
-    const lastLine = lines[lines.length - 1]?.trim();
+    const lastLine = lines[lines.length - 1]?.trimEnd();
     if (lastLine === '```' || lastLine === '~~~') {
       end = lines.length - 1;
     }

--- a/src/plugins/core/PluginManager.ts
+++ b/src/plugins/core/PluginManager.ts
@@ -4,6 +4,7 @@
 import { PluginAlreadyRegisteredError } from '@shared/errors';
 
 import { MarkdownRenderer, createMarkdownRenderer } from './MarkdownRenderer';
+import { isPreviewablePlugin, type PreviewablePlugin } from '../types/preview';
 
 import type { MarkdownRendererOptions } from './MarkdownRenderer';
 import type {
@@ -204,6 +205,21 @@ export class PluginManager {
    */
   getPlugin<T extends MarkdownPlugin = MarkdownPlugin>(pluginId: string): T | undefined {
     return this.renderer.getPlugin<T>(pluginId);
+  }
+
+  /**
+   * Return all enabled plugins that implement the PreviewablePlugin
+   * capability. Order matches the order plugins were enabled.
+   */
+  getPreviewablePlugins(): (MarkdownPlugin & PreviewablePlugin)[] {
+    const result: (MarkdownPlugin & PreviewablePlugin)[] = [];
+    for (const id of this.enabledPlugins) {
+      const plugin = this.renderer.getPlugin(id);
+      if (plugin && isPreviewablePlugin(plugin)) {
+        result.push(plugin);
+      }
+    }
+    return result;
   }
 
   /**

--- a/src/plugins/types/preview.ts
+++ b/src/plugins/types/preview.ts
@@ -1,0 +1,46 @@
+/**
+ * PreviewablePlugin - Optional plugin capability for live-preview editing.
+ *
+ * A plugin that owns a particular kind of slice (e.g. MermaidPlugin owns
+ * ```mermaid fences) implements this so the editor can give the user a
+ * live-preview-above-source editing surface. The four methods are stateless
+ * on the plugin: matchesSlice/extractSource/applySourceToRaw are pure;
+ * renderPreview is async and mutates the target element.
+ */
+import type { MarkdownPlugin } from '@shared/types';
+import type { MarkdownSlice } from '../../renderer/services/MarkdownSlicer';
+
+export interface PreviewablePlugin {
+  /** Does this plugin own the given slice? Fast and side-effect-free. */
+  matchesSlice(slice: MarkdownSlice): boolean;
+
+  /** Extract the user-editable source from the slice's raw markdown
+   *  (e.g. strip ```mermaid fences). */
+  extractSource(slice: MarkdownSlice): string;
+
+  /** Render `source` into `target`, replacing its contents on success.
+   *  MUST NOT throw — errors are returned so the caller can keep the
+   *  previous good preview visible. On `{ ok: false }` `target` MUST
+   *  be left unchanged. */
+  renderPreview(
+    source: string,
+    target: HTMLElement,
+  ): Promise<{ ok: true } | { ok: false; error: string }>;
+
+  /** Inverse of extractSource — wrap the edited source back into a full
+   *  slice raw. Implementations may consult `slice.raw` to preserve
+   *  details like a fence's info-string. */
+  applySourceToRaw(slice: MarkdownSlice, source: string): string;
+}
+
+/** Runtime duck-type check. Returns true when `plugin` implements all four
+ *  PreviewablePlugin methods. */
+export function isPreviewablePlugin(
+  plugin: MarkdownPlugin,
+): plugin is MarkdownPlugin & PreviewablePlugin {
+  const p = plugin as Partial<PreviewablePlugin>;
+  return typeof p.matchesSlice === 'function'
+      && typeof p.extractSource === 'function'
+      && typeof p.renderPreview === 'function'
+      && typeof p.applySourceToRaw === 'function';
+}

--- a/src/renderer/components/EditModeController.ts
+++ b/src/renderer/components/EditModeController.ts
@@ -11,6 +11,8 @@ import { InlineEditor } from './InlineEditor';
 import type { InlineMark } from './InlineEditor';
 import { FloatingFormatToolbar, type ToolbarAction } from './FloatingFormatToolbar';
 import { canSerialize } from '../services/inlineMarkdownSerializer';
+import { PreviewableSourceEditor } from './PreviewableSourceEditor';
+import type { PreviewablePlugin } from '../../plugins/types/preview';
 
 /**
  * Callbacks for EditModeController events
@@ -47,6 +49,7 @@ export class EditModeController {
   private activeEditIndex: number | null = null;
   private activeInlineEditor: InlineEditor | null = null;
   private activeRawTextarea: HTMLTextAreaElement | null = null;
+  private activePreviewableEditor: PreviewableSourceEditor | null = null;
   private toolbarVisible = false;
   private toolbar: FloatingFormatToolbar | null = null;
   private activeMenu: HTMLElement | null = null;
@@ -187,7 +190,27 @@ export class EditModeController {
     const contentEl = el.querySelector<HTMLElement>('.slice-content');
     if (!contentEl) return;
 
-    // Unsupported inline content is handled by the raw editor (Task 10).
+    // Previewable plugin opt-in (e.g. mermaid live preview).
+    const previewable = this.findPreviewablePluginFor(slice);
+    if (previewable) {
+      this.activeEditIndex = sliceIndex;
+      el.classList.add('slice-editing');
+      this.activePreviewableEditor = new PreviewableSourceEditor(
+        contentEl, slice, previewable,
+        { onCommit: (newRaw) => this.applyRawCommit(sliceIndex, newRaw) },
+      );
+      this.activePreviewableEditor.start();
+      return;
+    }
+
+    // Code slices without a previewable plugin fall back to raw editing —
+    // WYSIWYG round-tripping of fenced code blocks is not supported.
+    if (slice.type === 'code') {
+      this.startRawEdit(sliceIndex);
+      return;
+    }
+
+    // Unsupported inline content is handled by the raw editor.
     if (!canSerialize(contentEl)) {
       this.startRawEdit(sliceIndex);
       return;
@@ -293,19 +316,26 @@ export class EditModeController {
   }
 
   /**
-   * Commit a raw-textarea edit: the textarea value is the slice's markdown
-   * verbatim — no block-prefix reconciliation needed.
+   * Commit a raw-textarea edit: reads the textarea value then delegates to
+   * applyRawCommit for the shared re-render path.
    */
   private commitRawEdit(sliceIndex: number): void {
     const textarea = this.activeRawTextarea;
     this.activeRawTextarea = null;
     if (!textarea) return;
+    this.applyRawCommit(sliceIndex, textarea.value);
+  }
 
+  /**
+   * Shared "raw commit" path used by both the slim raw textarea and the
+   * PreviewableSourceEditor. Updates the slice via the slicer, fires
+   * onContentChange, and re-renders the slice.
+   */
+  private applyRawCommit(sliceIndex: number, newRaw: string): void {
     const slice = this.slices.find((s) => s.index === sliceIndex);
     const el = this.sliceElements.get(sliceIndex);
     if (!slice || !el) return;
 
-    const newRaw = textarea.value;
     if (newRaw !== slice.raw) {
       const result = this.slicer.updateSlice(this.slices, sliceIndex, newRaw);
       this.rawMarkdown = result.markdown;
@@ -327,6 +357,20 @@ export class EditModeController {
       });
       void this.pluginManager.postRender(contentEl as HTMLElement);
     }
+  }
+
+  /**
+   * Find the first previewable plugin that claims the given slice, or null.
+   */
+  private findPreviewablePluginFor(slice: MarkdownSlice): PreviewablePlugin | null {
+    const pm = this.pluginManager as PluginManager & {
+      getPreviewablePlugins?: () => (PreviewablePlugin & { metadata: unknown })[];
+    };
+    if (typeof pm.getPreviewablePlugins !== 'function') return null;
+    for (const plugin of pm.getPreviewablePlugins()) {
+      if (plugin.matchesSlice(slice)) return plugin;
+    }
+    return null;
   }
 
   /**
@@ -472,6 +516,12 @@ export class EditModeController {
     const sliceIndex = this.activeEditIndex;
     this.activeEditIndex = null;
 
+    if (this.activePreviewableEditor) {
+      const editor = this.activePreviewableEditor;
+      this.activePreviewableEditor = null;
+      editor.commit();
+      return;
+    }
     if (this.activeRawTextarea) {
       this.commitRawEdit(sliceIndex);
       return;

--- a/src/renderer/components/PreviewableSourceEditor.ts
+++ b/src/renderer/components/PreviewableSourceEditor.ts
@@ -12,8 +12,9 @@
  *       <span class="preview-source-error-text"></span>
  *     <textarea class="slice-raw-editor">    ← editor (bottom)
  *
- * Subsequent tasks add: debounced re-render on input (Task 8), race control
- * (Task 9), error chip toggling (Task 10), Esc-commits (Task 11).
+ * Features: debounced 250ms re-render on input, race control via monotonic
+ * requestId + scratch container (last keystroke wins), inline error chip
+ * for {ok:false} renders, and idempotent commit on Esc/external trigger.
  */
 import type { MarkdownSlice } from '../services/MarkdownSlicer';
 import type { PreviewablePlugin } from '../../plugins/types/preview';

--- a/src/renderer/components/PreviewableSourceEditor.ts
+++ b/src/renderer/components/PreviewableSourceEditor.ts
@@ -105,7 +105,10 @@ export class PreviewableSourceEditor {
     if (this.committed || myId !== this.latestRenderId) return;
     if (result.ok) {
       this.previewEl.replaceChildren(...Array.from(scratch.childNodes));
+      this.errorEl.hidden = true;
+    } else {
+      this.errorTextEl.textContent = result.error;
+      this.errorEl.hidden = false;
     }
-    // {ok: false} handling is added in Task 10.
   }
 }

--- a/src/renderer/components/PreviewableSourceEditor.ts
+++ b/src/renderer/components/PreviewableSourceEditor.ts
@@ -1,0 +1,81 @@
+/**
+ * PreviewableSourceEditor - Drives a "preview above source" editing session
+ * for a slice owned by a PreviewablePlugin.
+ *
+ * Layout it builds inside the passed-in `.slice-content`:
+ *
+ *   <div class="slice-content">
+ *     <div class="preview-source-preview">   ← preview (top, populated initially
+ *                                              with the existing rendered content
+ *                                              moved from the slice-content)
+ *     <div class="preview-source-error" hidden>
+ *       <span class="preview-source-error-text"></span>
+ *     <textarea class="slice-raw-editor">    ← editor (bottom)
+ *
+ * Subsequent tasks add: debounced re-render on input (Task 8), race control
+ * (Task 9), error chip toggling (Task 10), Esc-commits (Task 11).
+ */
+import type { MarkdownSlice } from '../services/MarkdownSlicer';
+import type { PreviewablePlugin } from '../../plugins/types/preview';
+
+export interface PreviewableSourceEditorCallbacks {
+  /** Called once when the session commits, with the slice's new raw markdown. */
+  onCommit: (newRaw: string) => void;
+}
+
+export class PreviewableSourceEditor {
+  private el: HTMLElement;
+  private slice: MarkdownSlice;
+  private plugin: PreviewablePlugin;
+  private callbacks: PreviewableSourceEditorCallbacks;
+  private committed = false;
+  private previewEl!: HTMLElement;
+  private errorEl!: HTMLElement;
+  private errorTextEl!: HTMLElement;
+  private textarea!: HTMLTextAreaElement;
+
+  constructor(
+    el: HTMLElement,
+    slice: MarkdownSlice,
+    plugin: PreviewablePlugin,
+    callbacks: PreviewableSourceEditorCallbacks,
+  ) {
+    this.el = el;
+    this.slice = slice;
+    this.plugin = plugin;
+    this.callbacks = callbacks;
+  }
+
+  start(): void {
+    // Capture the slice-content's current children (the existing rendered
+    // preview, e.g. a <div.mermaid-container> with SVG) — we'll move them
+    // into the new preview area below.
+    const existingChildren = Array.from(this.el.childNodes);
+
+    this.previewEl = document.createElement('div');
+    this.previewEl.className = 'preview-source-preview';
+    for (const child of existingChildren) this.previewEl.appendChild(child);
+
+    this.errorEl = document.createElement('div');
+    this.errorEl.className = 'preview-source-error';
+    this.errorEl.hidden = true;
+    this.errorTextEl = document.createElement('span');
+    this.errorTextEl.className = 'preview-source-error-text';
+    this.errorEl.appendChild(this.errorTextEl);
+
+    this.textarea = document.createElement('textarea');
+    this.textarea.className = 'slice-raw-editor';
+    this.textarea.spellcheck = false;
+    this.textarea.value = this.plugin.extractSource(this.slice);
+
+    this.el.replaceChildren(this.previewEl, this.errorEl, this.textarea);
+    this.textarea.focus();
+  }
+
+  commit(): void {
+    if (this.committed) return;
+    this.committed = true;
+    const newRaw = this.plugin.applySourceToRaw(this.slice, this.textarea.value);
+    this.callbacks.onCommit(newRaw);
+  }
+}

--- a/src/renderer/components/PreviewableSourceEditor.ts
+++ b/src/renderer/components/PreviewableSourceEditor.ts
@@ -18,6 +18,8 @@
 import type { MarkdownSlice } from '../services/MarkdownSlicer';
 import type { PreviewablePlugin } from '../../plugins/types/preview';
 
+const DEBOUNCE_MS = 250;
+
 export interface PreviewableSourceEditorCallbacks {
   /** Called once when the session commits, with the slice's new raw markdown. */
   onCommit: (newRaw: string) => void;
@@ -29,6 +31,7 @@ export class PreviewableSourceEditor {
   private plugin: PreviewablePlugin;
   private callbacks: PreviewableSourceEditorCallbacks;
   private committed = false;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private previewEl!: HTMLElement;
   private errorEl!: HTMLElement;
   private errorTextEl!: HTMLElement;
@@ -70,12 +73,31 @@ export class PreviewableSourceEditor {
 
     this.el.replaceChildren(this.previewEl, this.errorEl, this.textarea);
     this.textarea.focus();
+    this.textarea.addEventListener('input', this.onInput);
   }
 
   commit(): void {
     if (this.committed) return;
     this.committed = true;
+    if (this.debounceTimer !== null) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    this.textarea.removeEventListener('input', this.onInput);
     const newRaw = this.plugin.applySourceToRaw(this.slice, this.textarea.value);
     this.callbacks.onCommit(newRaw);
+  }
+
+  private readonly onInput = (): void => {
+    if (this.debounceTimer !== null) clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      void this.runRender();
+    }, DEBOUNCE_MS);
+  };
+
+  private async runRender(): Promise<void> {
+    const source = this.textarea.value;
+    await this.plugin.renderPreview(source, this.previewEl);
   }
 }

--- a/src/renderer/components/PreviewableSourceEditor.ts
+++ b/src/renderer/components/PreviewableSourceEditor.ts
@@ -32,6 +32,7 @@ export class PreviewableSourceEditor {
   private callbacks: PreviewableSourceEditorCallbacks;
   private committed = false;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private latestRenderId = 0;
   private previewEl!: HTMLElement;
   private errorEl!: HTMLElement;
   private errorTextEl!: HTMLElement;
@@ -97,7 +98,14 @@ export class PreviewableSourceEditor {
   };
 
   private async runRender(): Promise<void> {
+    const myId = ++this.latestRenderId;
     const source = this.textarea.value;
-    await this.plugin.renderPreview(source, this.previewEl);
+    const scratch = document.createElement('div');
+    const result = await this.plugin.renderPreview(source, scratch);
+    if (this.committed || myId !== this.latestRenderId) return;
+    if (result.ok) {
+      this.previewEl.replaceChildren(...Array.from(scratch.childNodes));
+    }
+    // {ok: false} handling is added in Task 10.
   }
 }

--- a/src/renderer/components/PreviewableSourceEditor.ts
+++ b/src/renderer/components/PreviewableSourceEditor.ts
@@ -75,6 +75,7 @@ export class PreviewableSourceEditor {
     this.el.replaceChildren(this.previewEl, this.errorEl, this.textarea);
     this.textarea.focus();
     this.textarea.addEventListener('input', this.onInput);
+    this.textarea.addEventListener('keydown', this.onKeyDown);
   }
 
   commit(): void {
@@ -85,9 +86,17 @@ export class PreviewableSourceEditor {
       this.debounceTimer = null;
     }
     this.textarea.removeEventListener('input', this.onInput);
+    this.textarea.removeEventListener('keydown', this.onKeyDown);
     const newRaw = this.plugin.applySourceToRaw(this.slice, this.textarea.value);
     this.callbacks.onCommit(newRaw);
   }
+
+  private readonly onKeyDown = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      this.commit();
+    }
+  };
 
   private readonly onInput = (): void => {
     if (this.debounceTimer !== null) clearTimeout(this.debounceTimer);

--- a/tests/unit/plugins/builtin/MermaidPlugin.test.ts
+++ b/tests/unit/plugins/builtin/MermaidPlugin.test.ts
@@ -359,5 +359,15 @@ Some text below.
       const s = slice({ raw: '```mermaid\ngraph TD\n\n  A --> B\n```' });
       expect(plugin.extractSource(s)).toBe('graph TD\n\n  A --> B');
     });
+
+    it('returns the raw unchanged when there are no fences', () => {
+      const s = slice({ raw: 'graph TD\nA --> B' });
+      expect(plugin.extractSource(s)).toBe('graph TD\nA --> B');
+    });
+
+    it('strips only the opening fence when the closing fence is missing', () => {
+      const s = slice({ raw: '```mermaid\ngraph TD\nA --> B' });
+      expect(plugin.extractSource(s)).toBe('graph TD\nA --> B');
+    });
   });
 });

--- a/tests/unit/plugins/builtin/MermaidPlugin.test.ts
+++ b/tests/unit/plugins/builtin/MermaidPlugin.test.ts
@@ -19,6 +19,17 @@ vi.mock('mermaid', () => ({
 }));
 
 describe('MermaidPlugin', () => {
+  function slice(partial: Partial<MarkdownSlice>): MarkdownSlice {
+    return {
+      index: 0,
+      type: 'code',
+      raw: '',
+      startLine: 0,
+      endLine: 0,
+      ...partial,
+    };
+  }
+
   let plugin: MermaidPlugin;
   let renderer: MarkdownRenderer;
 
@@ -303,17 +314,6 @@ Some text below.
   });
 
   describe('matchesSlice', () => {
-    function slice(partial: Partial<MarkdownSlice>): MarkdownSlice {
-      return {
-        index: 0,
-        type: 'code',
-        raw: '',
-        startLine: 0,
-        endLine: 0,
-        ...partial,
-      };
-    }
-
     it('returns true for a code slice with a ```mermaid opening fence', () => {
       expect(plugin.matchesSlice(slice({ raw: '```mermaid\nA --> B\n```' }))).toBe(true);
     });
@@ -336,6 +336,28 @@ Some text below.
 
     it('returns true for tilde-fenced mermaid blocks', () => {
       expect(plugin.matchesSlice(slice({ raw: '~~~mermaid\nA --> B\n~~~' }))).toBe(true);
+    });
+  });
+
+  describe('extractSource', () => {
+    it('strips opening ```mermaid fence and closing ``` fence', () => {
+      const s = slice({ raw: '```mermaid\ngraph TD\nA --> B\n```' });
+      expect(plugin.extractSource(s)).toBe('graph TD\nA --> B');
+    });
+
+    it('strips opening fence with info-string suffix', () => {
+      const s = slice({ raw: '```mermaid theme=dark\ngraph TD\nA --> B\n```' });
+      expect(plugin.extractSource(s)).toBe('graph TD\nA --> B');
+    });
+
+    it('strips tilde fences (opening and closing)', () => {
+      const s = slice({ raw: '~~~mermaid\ngraph TD\nA --> B\n~~~' });
+      expect(plugin.extractSource(s)).toBe('graph TD\nA --> B');
+    });
+
+    it('preserves blank lines and trailing whitespace inside the content', () => {
+      const s = slice({ raw: '```mermaid\ngraph TD\n\n  A --> B\n```' });
+      expect(plugin.extractSource(s)).toBe('graph TD\n\n  A --> B');
     });
   });
 });

--- a/tests/unit/plugins/builtin/MermaidPlugin.test.ts
+++ b/tests/unit/plugins/builtin/MermaidPlugin.test.ts
@@ -8,6 +8,7 @@ import {
 import { MarkdownRenderer } from '@plugins/core/MarkdownRenderer';
 import { BUILTIN_PLUGINS } from '@shared/constants';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { MarkdownSlice } from '@renderer/services/MarkdownSlicer';
 
 // Mock mermaid module
 vi.mock('mermaid', () => ({
@@ -298,6 +299,39 @@ Some text below.
       expect(result).toContain('Diagram</h1>');
       expect(result).toContain('mermaid-container');
       expect(result).toContain('Some text below');
+    });
+  });
+
+  describe('matchesSlice', () => {
+    function slice(partial: Partial<MarkdownSlice>): MarkdownSlice {
+      return {
+        index: 0,
+        type: 'code',
+        raw: '',
+        startLine: 0,
+        endLine: 0,
+        ...partial,
+      };
+    }
+
+    it('returns true for a code slice with a ```mermaid opening fence', () => {
+      expect(plugin.matchesSlice(slice({ raw: '```mermaid\nA --> B\n```' }))).toBe(true);
+    });
+
+    it('returns true when the mermaid fence has an info-string suffix', () => {
+      expect(plugin.matchesSlice(slice({ raw: '```mermaid theme=dark\nA --> B\n```' }))).toBe(true);
+    });
+
+    it('returns false for a code slice in another language', () => {
+      expect(plugin.matchesSlice(slice({ raw: '```js\nconsole.log(1);\n```' }))).toBe(false);
+    });
+
+    it('returns false for non-code slice types', () => {
+      expect(plugin.matchesSlice(slice({ type: 'paragraph', raw: 'mermaid' }))).toBe(false);
+    });
+
+    it('returns false when the slice has no opening fence', () => {
+      expect(plugin.matchesSlice(slice({ raw: 'graph TD\nA --> B' }))).toBe(false);
     });
   });
 });

--- a/tests/unit/plugins/builtin/MermaidPlugin.test.ts
+++ b/tests/unit/plugins/builtin/MermaidPlugin.test.ts
@@ -333,5 +333,9 @@ Some text below.
     it('returns false when the slice has no opening fence', () => {
       expect(plugin.matchesSlice(slice({ raw: 'graph TD\nA --> B' }))).toBe(false);
     });
+
+    it('returns true for tilde-fenced mermaid blocks', () => {
+      expect(plugin.matchesSlice(slice({ raw: '~~~mermaid\nA --> B\n~~~' }))).toBe(true);
+    });
   });
 });

--- a/tests/unit/plugins/builtin/MermaidPlugin.test.ts
+++ b/tests/unit/plugins/builtin/MermaidPlugin.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 /**
  * MermaidPlugin unit tests
  */
@@ -396,6 +397,36 @@ Some text below.
     it('falls back to ```mermaid when slice.raw has no recognisable opening fence', () => {
       const s = slice({ raw: 'no fence' });
       expect(plugin.applySourceToRaw(s, 'graph TD')).toBe('```mermaid\ngraph TD\n```');
+    });
+  });
+
+  describe('renderPreview', () => {
+    it('replaces target contents with rendered SVG on success', async () => {
+      const target = document.createElement('div');
+      target.textContent = 'placeholder';
+      const result = await plugin.renderPreview('graph TD\nA --> B', target);
+      expect(result).toEqual({ ok: true });
+      expect(target.children.length).toBe(1);
+      expect(target.children[0]!.tagName.toLowerCase()).toBe('svg');
+      expect(target.textContent).toBe('Mock SVG');
+    });
+
+    it('leaves target untouched and returns the error on failure', async () => {
+      const mermaid = (await import('mermaid')).default;
+      vi.mocked(mermaid.render).mockRejectedValueOnce(new Error('Parse error'));
+      const target = document.createElement('div');
+      target.textContent = 'previous good preview';
+      const result = await plugin.renderPreview('bogus', target);
+      expect(result).toEqual({ ok: false, error: 'Parse error' });
+      expect(target.textContent).toBe('previous good preview');
+    });
+
+    it('returns an error when the mermaid library is not initialised', async () => {
+      const uninit = new MermaidPlugin();
+      const target = document.createElement('div');
+      const result = await uninit.renderPreview('graph TD', target);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toMatch(/not initialised/i);
     });
   });
 });

--- a/tests/unit/plugins/builtin/MermaidPlugin.test.ts
+++ b/tests/unit/plugins/builtin/MermaidPlugin.test.ts
@@ -370,4 +370,32 @@ Some text below.
       expect(plugin.extractSource(s)).toBe('graph TD\nA --> B');
     });
   });
+
+  describe('applySourceToRaw', () => {
+    it("re-wraps source with the slice's original opening info-string", () => {
+      const s = slice({ raw: '```mermaid\nold\n```' });
+      expect(plugin.applySourceToRaw(s, 'graph TD\nA --> B')).toBe(
+        '```mermaid\ngraph TD\nA --> B\n```',
+      );
+    });
+
+    it('preserves an info-string suffix on the opening fence', () => {
+      const s = slice({ raw: '```mermaid theme=dark\nold\n```' });
+      expect(plugin.applySourceToRaw(s, 'graph TD\nA --> B')).toBe(
+        '```mermaid theme=dark\ngraph TD\nA --> B\n```',
+      );
+    });
+
+    it('preserves tilde fences', () => {
+      const s = slice({ raw: '~~~mermaid\nold\n~~~' });
+      expect(plugin.applySourceToRaw(s, 'graph TD\nA --> B')).toBe(
+        '~~~mermaid\ngraph TD\nA --> B\n~~~',
+      );
+    });
+
+    it('falls back to ```mermaid when slice.raw has no recognisable opening fence', () => {
+      const s = slice({ raw: 'no fence' });
+      expect(plugin.applySourceToRaw(s, 'graph TD')).toBe('```mermaid\ngraph TD\n```');
+    });
+  });
 });

--- a/tests/unit/plugins/core/PluginManager.test.ts
+++ b/tests/unit/plugins/core/PluginManager.test.ts
@@ -62,7 +62,7 @@ function fakePreviewablePlugin(id: string): MarkdownPlugin & PreviewablePlugin {
     apply: () => {},
     matchesSlice: () => false,
     extractSource: () => '',
-    renderPreview: async () => ({ ok: true }),
+    renderPreview: () => Promise.resolve({ ok: true }),
     applySourceToRaw: (_s, source) => source,
   };
 }

--- a/tests/unit/plugins/core/PluginManager.test.ts
+++ b/tests/unit/plugins/core/PluginManager.test.ts
@@ -7,6 +7,10 @@ import {
   createPluginManager,
   type PluginFactory,
 } from '@plugins/core/PluginManager';
+import {
+  isPreviewablePlugin,
+  type PreviewablePlugin,
+} from '@plugins/types/preview';
 import { PluginAlreadyRegisteredError } from '@shared/errors';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -49,6 +53,17 @@ function createMockPluginFactory(
     }
 
     return plugin;
+  };
+}
+
+function fakePreviewablePlugin(id: string): MarkdownPlugin & PreviewablePlugin {
+  return {
+    metadata: { id, name: id, version: '1.0.0', description: '' },
+    apply: () => {},
+    matchesSlice: () => false,
+    extractSource: () => '',
+    renderPreview: async () => ({ ok: true }),
+    applySourceToRaw: (_s, source) => source,
   };
 }
 
@@ -373,38 +388,33 @@ describe('PluginManager', () => {
       expect(renderer).toBeInstanceOf(MarkdownRenderer);
     });
   });
-});
 
-import {
-  isPreviewablePlugin,
-  type PreviewablePlugin,
-} from '@plugins/types/preview';
+  describe('getPreviewablePlugins', () => {
+    it('returns only enabled plugins that implement the previewable capability', async () => {
+      const pm = new PluginManager();
+      pm.registerPluginFactory('mermaid-like', () => fakePreviewablePlugin('mermaid-like'));
+      pm.registerPluginFactory('plain', () => ({
+        metadata: { id: 'plain', name: 'plain', version: '1.0.0', description: '' },
+        apply: () => {},
+      }));
+      await pm.enablePlugin('mermaid-like');
+      await pm.enablePlugin('plain');
 
-function fakePreviewablePlugin(id: string): MarkdownPlugin & PreviewablePlugin {
-  return {
-    metadata: { id, name: id, version: '1.0.0', description: '' },
-    apply: () => {},
-    matchesSlice: () => false,
-    extractSource: () => '',
-    renderPreview: async () => ({ ok: true }),
-    applySourceToRaw: (_s, source) => source,
-  };
-}
+      const previewable = pm.getPreviewablePlugins();
+      expect(previewable).toHaveLength(1);
+      expect(isPreviewablePlugin(previewable[0]!)).toBe(true);
+      expect(previewable[0]!.metadata.id).toBe('mermaid-like');
+    });
 
-describe('getPreviewablePlugins', () => {
-  it('returns only enabled plugins that implement the previewable capability', async () => {
-    const pm = new PluginManager();
-    pm.registerPluginFactory('mermaid-like', () => fakePreviewablePlugin('mermaid-like'));
-    pm.registerPluginFactory('plain', () => ({
-      metadata: { id: 'plain', name: 'plain', version: '1.0.0', description: '' },
-      apply: () => {},
-    }));
-    await pm.enablePlugin('mermaid-like');
-    await pm.enablePlugin('plain');
-
-    const previewable = pm.getPreviewablePlugins();
-    expect(previewable).toHaveLength(1);
-    expect(isPreviewablePlugin(previewable[0]!)).toBe(true);
-    expect(previewable[0]!.metadata.id).toBe('mermaid-like');
+    it('excludes a previewable plugin that is registered but not enabled', async () => {
+      const pm = new PluginManager();
+      pm.registerPluginFactory('mermaid-like', () => fakePreviewablePlugin('mermaid-like'));
+      pm.registerPluginFactory('disabled', () => fakePreviewablePlugin('disabled'));
+      await pm.enablePlugin('mermaid-like');
+      // 'disabled' is registered but never enabled.
+      const previewable = pm.getPreviewablePlugins();
+      expect(previewable).toHaveLength(1);
+      expect(previewable[0]!.metadata.id).toBe('mermaid-like');
+    });
   });
 });

--- a/tests/unit/plugins/core/PluginManager.test.ts
+++ b/tests/unit/plugins/core/PluginManager.test.ts
@@ -374,3 +374,37 @@ describe('PluginManager', () => {
     });
   });
 });
+
+import {
+  isPreviewablePlugin,
+  type PreviewablePlugin,
+} from '@plugins/types/preview';
+
+function fakePreviewablePlugin(id: string): MarkdownPlugin & PreviewablePlugin {
+  return {
+    metadata: { id, name: id, version: '1.0.0', description: '' },
+    apply: () => {},
+    matchesSlice: () => false,
+    extractSource: () => '',
+    renderPreview: async () => ({ ok: true }),
+    applySourceToRaw: (_s, source) => source,
+  };
+}
+
+describe('getPreviewablePlugins', () => {
+  it('returns only enabled plugins that implement the previewable capability', async () => {
+    const pm = new PluginManager();
+    pm.registerPluginFactory('mermaid-like', () => fakePreviewablePlugin('mermaid-like'));
+    pm.registerPluginFactory('plain', () => ({
+      metadata: { id: 'plain', name: 'plain', version: '1.0.0', description: '' },
+      apply: () => {},
+    }));
+    await pm.enablePlugin('mermaid-like');
+    await pm.enablePlugin('plain');
+
+    const previewable = pm.getPreviewablePlugins();
+    expect(previewable).toHaveLength(1);
+    expect(isPreviewablePlugin(previewable[0]!)).toBe(true);
+    expect(previewable[0]!.metadata.id).toBe('mermaid-like');
+  });
+});

--- a/tests/unit/renderer/components/EditModeController.test.ts
+++ b/tests/unit/renderer/components/EditModeController.test.ts
@@ -298,7 +298,7 @@ function makePreviewableManager(): PluginManager {
       const lines = s.raw.split('\n');
       return lines.slice(1, -1).join('\n');
     },
-    renderPreview: async () => ({ ok: true as const }),
+    renderPreview: () => Promise.resolve({ ok: true as const }),
     applySourceToRaw: (_s: MarkdownSlice, source: string) => '```mermaid\n' + source + '\n```',
   };
   (pm as unknown as { getPreviewablePlugins: () => (MarkdownPlugin & PreviewablePlugin)[] })

--- a/tests/unit/renderer/components/EditModeController.test.ts
+++ b/tests/unit/renderer/components/EditModeController.test.ts
@@ -285,21 +285,24 @@ describe('EditModeController — floating toolbar wiring', () => {
 });
 
 import type { PreviewablePlugin } from '../../../../src/plugins/types/preview';
+import type { MarkdownSlice } from '../../../../src/renderer/services/MarkdownSlicer';
+import type { MarkdownPlugin } from '../../../../src/shared/types';
 
 function makePreviewableManager(): PluginManager {
-  const pm = makePluginManager() as unknown as PluginManager & {
-    getPreviewablePlugins: () => (PreviewablePlugin & { metadata: unknown })[];
-  };
-  pm.getPreviewablePlugins = () => [{
+  const pm = makePluginManager();
+  const plugin: MarkdownPlugin & PreviewablePlugin = {
     metadata: { id: 'mermaid', name: 'mermaid', version: '1.0.0', description: '' },
-    matchesSlice: (s) => s.type === 'code' && /^```mermaid\b/.test(s.raw.trimStart()),
-    extractSource: (s) => {
+    apply: () => {},
+    matchesSlice: (s: MarkdownSlice) => s.type === 'code' && /^```mermaid\b/.test(s.raw.trimStart()),
+    extractSource: (s: MarkdownSlice) => {
       const lines = s.raw.split('\n');
       return lines.slice(1, -1).join('\n');
     },
     renderPreview: async () => ({ ok: true as const }),
-    applySourceToRaw: (_s, source) => '```mermaid\n' + source + '\n```',
-  } as unknown as PreviewablePlugin & { metadata: unknown }];
+    applySourceToRaw: (_s: MarkdownSlice, source: string) => '```mermaid\n' + source + '\n```',
+  };
+  (pm as unknown as { getPreviewablePlugins: () => (MarkdownPlugin & PreviewablePlugin)[] })
+    .getPreviewablePlugins = () => [plugin];
   return pm;
 }
 

--- a/tests/unit/renderer/components/EditModeController.test.ts
+++ b/tests/unit/renderer/components/EditModeController.test.ts
@@ -283,3 +283,72 @@ describe('EditModeController — floating toolbar wiring', () => {
     expect(content.querySelector('strong')).not.toBe(null);
   });
 });
+
+import type { PreviewablePlugin } from '../../../../src/plugins/types/preview';
+
+function makePreviewableManager(): PluginManager {
+  const pm = makePluginManager() as unknown as PluginManager & {
+    getPreviewablePlugins: () => (PreviewablePlugin & { metadata: unknown })[];
+  };
+  pm.getPreviewablePlugins = () => [{
+    metadata: { id: 'mermaid', name: 'mermaid', version: '1.0.0', description: '' },
+    matchesSlice: (s) => s.type === 'code' && /^```mermaid\b/.test(s.raw.trimStart()),
+    extractSource: (s) => {
+      const lines = s.raw.split('\n');
+      return lines.slice(1, -1).join('\n');
+    },
+    renderPreview: async () => ({ ok: true as const }),
+    applySourceToRaw: (_s, source) => '```mermaid\n' + source + '\n```',
+  } as unknown as PreviewablePlugin & { metadata: unknown }];
+  return pm;
+}
+
+function setupPreviewable(): { container: HTMLElement; controller: EditModeController } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const controller = new EditModeController(container, makePreviewableManager());
+  return { container, controller };
+}
+
+describe('EditModeController — previewable mermaid editing', () => {
+  it('clicking a ```mermaid slice opens the PreviewableSourceEditor (preview + textarea coexist)', async () => {
+    const { container, controller } = setupPreviewable();
+    await controller.enter('```mermaid\nA --> B\n```');
+    const content = container.querySelector<HTMLElement>('.slice-content')!;
+    content.click();
+    expect(content.querySelector('.preview-source-preview')).not.toBe(null);
+    expect(content.querySelector('textarea.slice-raw-editor')).not.toBe(null);
+    expect(content.querySelector<HTMLTextAreaElement>('textarea')!.value).toBe('A --> B');
+  });
+
+  it('clicking a non-mermaid code slice still opens the regular raw editor (no preview area)', async () => {
+    const { container, controller } = setupPreviewable();
+    await controller.enter('```js\nconsole.log(1);\n```');
+    const content = container.querySelector<HTMLElement>('.slice-content')!;
+    content.click();
+    expect(content.querySelector('.preview-source-preview')).toBe(null);
+    expect(content.querySelector('textarea.slice-raw-editor')).not.toBe(null);
+  });
+
+  it('clicking a paragraph still opens the WYSIWYG inline editor', async () => {
+    const { container, controller } = setupPreviewable();
+    await controller.enter('Hello world');
+    const content = container.querySelector<HTMLElement>('.slice-content')!;
+    content.click();
+    expect(content.getAttribute('contenteditable')).toBe('true');
+    expect(content.querySelector('.preview-source-preview')).toBe(null);
+  });
+
+  it('committing a previewable edit updates the slice raw with the new fenced content', async () => {
+    const { container, controller } = setupPreviewable();
+    const onContentChange = vi.fn();
+    controller.setCallbacks({ onContentChange });
+    await controller.enter('```mermaid\nA --> B\n```');
+    container.querySelector<HTMLElement>('.slice-content')!.click();
+    const ta = container.querySelector<HTMLTextAreaElement>('textarea.slice-raw-editor')!;
+    ta.value = 'C --> D';
+    controller.commitActiveEditForTest();
+    expect(controller.getMarkdown()).toBe('```mermaid\nC --> D\n```');
+    expect(onContentChange).toHaveBeenCalledWith('```mermaid\nC --> D\n```');
+  });
+});

--- a/tests/unit/renderer/components/PreviewableSourceEditor.test.ts
+++ b/tests/unit/renderer/components/PreviewableSourceEditor.test.ts
@@ -25,7 +25,7 @@ function fakePlugin(overrides: Partial<PreviewablePlugin> = {}): MarkdownPlugin 
     apply: () => {},
     matchesSlice: () => true,
     extractSource: () => 'A --> B',
-    renderPreview: vi.fn(async () => ({ ok: true as const })),
+    renderPreview: vi.fn(() => Promise.resolve({ ok: true as const })),
     applySourceToRaw: (_s, source) => '```mermaid\n' + source + '\n```',
     ...overrides,
   };
@@ -129,10 +129,10 @@ describe('PreviewableSourceEditor debounced render', () => {
     try {
       const el = contentEl('<div class="mermaid-container"><svg>old</svg></div>');
       const plugin = fakePlugin({
-        renderPreview: vi.fn(async (_src, target) => {
+        renderPreview: vi.fn((_src, target) => {
           target.replaceChildren();
           target.insertAdjacentHTML('afterbegin', '<svg>new</svg>');
-          return { ok: true as const };
+          return Promise.resolve({ ok: true as const });
         }),
       });
       const editor = new PreviewableSourceEditor(el, slice(), plugin, { onCommit: vi.fn() });
@@ -220,7 +220,7 @@ describe('PreviewableSourceEditor error handling', () => {
     try {
       const el = contentEl('<div class="mermaid-container"><svg>good</svg></div>');
       const plugin = fakePlugin({
-        renderPreview: vi.fn(async () => ({ ok: false as const, error: 'Syntax error: foo' })),
+        renderPreview: vi.fn(() => Promise.resolve({ ok: false as const, error: 'Syntax error: foo' })),
       });
       const editor = new PreviewableSourceEditor(el, slice(), plugin, { onCommit: vi.fn() });
       editor.start();
@@ -248,12 +248,12 @@ describe('PreviewableSourceEditor error handling', () => {
       const el = contentEl('<div class="mermaid-container"><svg>good</svg></div>');
       let next: { ok: true } | { ok: false; error: string } = { ok: false, error: 'oops' };
       const plugin = fakePlugin({
-        renderPreview: vi.fn(async (_src, target) => {
+        renderPreview: vi.fn((_src, target) => {
           if (next.ok) {
             target.replaceChildren();
             target.insertAdjacentHTML('afterbegin', '<svg>new</svg>');
           }
-          return next;
+          return Promise.resolve(next);
         }),
       });
       const editor = new PreviewableSourceEditor(el, slice(), plugin, { onCommit: vi.fn() });

--- a/tests/unit/renderer/components/PreviewableSourceEditor.test.ts
+++ b/tests/unit/renderer/components/PreviewableSourceEditor.test.ts
@@ -213,3 +213,67 @@ describe('PreviewableSourceEditor race control', () => {
     }
   });
 });
+
+describe('PreviewableSourceEditor error handling', () => {
+  it('keeps the previous preview and shows the error chip on { ok: false }', async () => {
+    vi.useFakeTimers();
+    try {
+      const el = contentEl('<div class="mermaid-container"><svg>good</svg></div>');
+      const plugin = fakePlugin({
+        renderPreview: vi.fn(async () => ({ ok: false as const, error: 'Syntax error: foo' })),
+      });
+      const editor = new PreviewableSourceEditor(el, slice(), plugin, { onCommit: vi.fn() });
+      editor.start();
+      const ta = el.querySelector<HTMLTextAreaElement>('textarea')!;
+      ta.value = 'bad';
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.runAllTimersAsync();
+
+      // Previous preview untouched
+      const previewSvg = el.querySelector('.preview-source-preview .mermaid-container svg');
+      expect(previewSvg!.textContent).toBe('good');
+      // Error chip visible with the message
+      const errorChip = el.querySelector<HTMLElement>('.preview-source-error')!;
+      expect(errorChip.hidden).toBe(false);
+      expect(errorChip.querySelector('.preview-source-error-text')!.textContent).toBe('Syntax error: foo');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('hides the error chip again on the next successful render', async () => {
+    vi.useFakeTimers();
+    try {
+      const el = contentEl('<div class="mermaid-container"><svg>good</svg></div>');
+      let next: { ok: true } | { ok: false; error: string } = { ok: false, error: 'oops' };
+      const plugin = fakePlugin({
+        renderPreview: vi.fn(async (_src, target) => {
+          if (next.ok) {
+            target.replaceChildren();
+            target.insertAdjacentHTML('afterbegin', '<svg>new</svg>');
+          }
+          return next;
+        }),
+      });
+      const editor = new PreviewableSourceEditor(el, slice(), plugin, { onCommit: vi.fn() });
+      editor.start();
+      const ta = el.querySelector<HTMLTextAreaElement>('textarea')!;
+
+      ta.value = 'bad';
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.runAllTimersAsync();
+      expect(el.querySelector<HTMLElement>('.preview-source-error')!.hidden).toBe(false);
+
+      next = { ok: true };
+      ta.value = 'good';
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.runAllTimersAsync();
+      expect(el.querySelector<HTMLElement>('.preview-source-error')!.hidden).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/unit/renderer/components/PreviewableSourceEditor.test.ts
+++ b/tests/unit/renderer/components/PreviewableSourceEditor.test.ts
@@ -277,3 +277,16 @@ describe('PreviewableSourceEditor error handling', () => {
     }
   });
 });
+
+describe('PreviewableSourceEditor Esc', () => {
+  it('Escape on the textarea commits the session', () => {
+    const el = contentEl('<div class="mermaid-container"></div>');
+    const onCommit = vi.fn();
+    const editor = new PreviewableSourceEditor(el, slice(), fakePlugin(), { onCommit });
+    editor.start();
+    const ta = el.querySelector<HTMLTextAreaElement>('textarea')!;
+    ta.value = 'C --> D';
+    ta.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+    expect(onCommit).toHaveBeenCalledWith('```mermaid\nC --> D\n```');
+  });
+});

--- a/tests/unit/renderer/components/PreviewableSourceEditor.test.ts
+++ b/tests/unit/renderer/components/PreviewableSourceEditor.test.ts
@@ -168,3 +168,48 @@ describe('PreviewableSourceEditor debounced render', () => {
     }
   });
 });
+
+describe('PreviewableSourceEditor race control', () => {
+  it('drops a slow earlier render result when a newer render has fired', async () => {
+    vi.useFakeTimers();
+    try {
+      const el = contentEl('<div class="mermaid-container">initial</div>');
+      let resolveFirst!: () => void;
+      const firstPromise = new Promise<void>((r) => { resolveFirst = r; });
+      const renderPreview = vi.fn(async (source: string, target: HTMLElement) => {
+        if (source === 'slow') {
+          await firstPromise;
+          target.replaceChildren();
+          target.insertAdjacentHTML('afterbegin', '<svg>slow</svg>');
+          return { ok: true as const };
+        }
+        target.replaceChildren();
+        target.insertAdjacentHTML('afterbegin', '<svg>fast</svg>');
+        return { ok: true as const };
+      });
+      const plugin = fakePlugin({ renderPreview });
+      const editor = new PreviewableSourceEditor(el, slice(), plugin, { onCommit: vi.fn() });
+      editor.start();
+      const ta = el.querySelector<HTMLTextAreaElement>('textarea')!;
+
+      ta.value = 'slow';
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+      await vi.advanceTimersByTimeAsync(250); // first render starts but awaits
+
+      ta.value = 'fast';
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+      await vi.advanceTimersByTimeAsync(250); // second render starts and completes
+      await vi.runAllTimersAsync();
+
+      // Now release the slow first render — it should NOT overwrite "fast".
+      resolveFirst();
+      await vi.runAllTimersAsync();
+
+      const previewSvg = el.querySelector('.preview-source-preview > svg');
+      expect(previewSvg).not.toBe(null);
+      expect(previewSvg!.textContent).toBe('fast');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/unit/renderer/components/PreviewableSourceEditor.test.ts
+++ b/tests/unit/renderer/components/PreviewableSourceEditor.test.ts
@@ -81,3 +81,90 @@ describe('PreviewableSourceEditor lifecycle', () => {
     expect(onCommit).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('PreviewableSourceEditor debounced render', () => {
+  it('calls plugin.renderPreview after a 250ms pause in typing', async () => {
+    vi.useFakeTimers();
+    try {
+      const el = contentEl('<div class="mermaid-container"></div>');
+      const plugin = fakePlugin();
+      const editor = new PreviewableSourceEditor(el, slice(), plugin, { onCommit: vi.fn() });
+      editor.start();
+      const ta = el.querySelector<HTMLTextAreaElement>('textarea')!;
+      ta.value = 'X --> Y';
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+      expect(plugin.renderPreview).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(250);
+      expect(plugin.renderPreview).toHaveBeenCalledTimes(1);
+      expect(plugin.renderPreview).toHaveBeenCalledWith('X --> Y', expect.any(HTMLElement));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('coalesces rapid keystrokes into one render after the pause', async () => {
+    vi.useFakeTimers();
+    try {
+      const el = contentEl('<div class="mermaid-container"></div>');
+      const plugin = fakePlugin();
+      const editor = new PreviewableSourceEditor(el, slice(), plugin, { onCommit: vi.fn() });
+      editor.start();
+      const ta = el.querySelector<HTMLTextAreaElement>('textarea')!;
+      for (const v of ['a', 'ab', 'abc', 'abcd']) {
+        ta.value = v;
+        ta.dispatchEvent(new Event('input', { bubbles: true }));
+        await vi.advanceTimersByTimeAsync(100); // less than 250ms
+      }
+      expect(plugin.renderPreview).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(250);
+      expect(plugin.renderPreview).toHaveBeenCalledTimes(1);
+      expect(plugin.renderPreview).toHaveBeenCalledWith('abcd', expect.any(HTMLElement));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('replaces preview contents on { ok: true }', async () => {
+    vi.useFakeTimers();
+    try {
+      const el = contentEl('<div class="mermaid-container"><svg>old</svg></div>');
+      const plugin = fakePlugin({
+        renderPreview: vi.fn(async (_src, target) => {
+          target.replaceChildren();
+          target.insertAdjacentHTML('afterbegin', '<svg>new</svg>');
+          return { ok: true as const };
+        }),
+      });
+      const editor = new PreviewableSourceEditor(el, slice(), plugin, { onCommit: vi.fn() });
+      editor.start();
+      const ta = el.querySelector<HTMLTextAreaElement>('textarea')!;
+      ta.value = 'X --> Y';
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.runAllTimersAsync();
+      const previewSvg = el.querySelector('.preview-source-preview > svg');
+      expect(previewSvg).not.toBe(null);
+      expect(previewSvg!.textContent).toBe('new');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('cancels a pending debounced render when commit is called', async () => {
+    vi.useFakeTimers();
+    try {
+      const el = contentEl('<div class="mermaid-container"></div>');
+      const plugin = fakePlugin();
+      const editor = new PreviewableSourceEditor(el, slice(), plugin, { onCommit: vi.fn() });
+      editor.start();
+      const ta = el.querySelector<HTMLTextAreaElement>('textarea')!;
+      ta.value = 'X --> Y';
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+      editor.commit();
+      await vi.advanceTimersByTimeAsync(500);
+      expect(plugin.renderPreview).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/unit/renderer/components/PreviewableSourceEditor.test.ts
+++ b/tests/unit/renderer/components/PreviewableSourceEditor.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { PreviewableSourceEditor } from '../../../../src/renderer/components/PreviewableSourceEditor';
+import type { PreviewablePlugin } from '../../../../src/plugins/types/preview';
+import type { MarkdownSlice } from '../../../../src/renderer/services/MarkdownSlicer';
+import type { MarkdownPlugin } from '../../../../src/shared/types';
+
+function contentEl(html: string): HTMLElement {
+  const el = document.createElement('div');
+  el.className = 'slice-content';
+  el.insertAdjacentHTML('afterbegin', html);
+  document.body.appendChild(el);
+  return el;
+}
+
+function slice(partial: Partial<MarkdownSlice> = {}): MarkdownSlice {
+  return { index: 0, type: 'code', raw: '```mermaid\nA --> B\n```', startLine: 0, endLine: 2, ...partial };
+}
+
+function fakePlugin(overrides: Partial<PreviewablePlugin> = {}): MarkdownPlugin & PreviewablePlugin {
+  return {
+    metadata: { id: 'fake', name: 'fake', version: '1.0.0', description: '' },
+    apply: () => {},
+    matchesSlice: () => true,
+    extractSource: () => 'A --> B',
+    renderPreview: vi.fn(async () => ({ ok: true as const })),
+    applySourceToRaw: (_s, source) => '```mermaid\n' + source + '\n```',
+    ...overrides,
+  };
+}
+
+describe('PreviewableSourceEditor lifecycle', () => {
+  it('start() builds preview/error-chip/textarea structure inside contentEl', () => {
+    const el = contentEl('<div class="mermaid-container"><svg>old</svg></div>');
+    const editor = new PreviewableSourceEditor(el, slice(), fakePlugin(), { onCommit: vi.fn() });
+    editor.start();
+    expect(el.querySelector('.preview-source-preview')).not.toBe(null);
+    expect(el.querySelector('.preview-source-error')).not.toBe(null);
+    expect(el.querySelector('textarea.slice-raw-editor')).not.toBe(null);
+    // existing rendered SVG was moved into the preview area
+    const movedSvg = el.querySelector('.preview-source-preview .mermaid-container svg');
+    expect(movedSvg).not.toBe(null);
+    expect(movedSvg!.textContent).toBe('old');
+  });
+
+  it('start() seeds textarea with plugin.extractSource and focuses it', () => {
+    const el = contentEl('<div class="mermaid-container"></div>');
+    const editor = new PreviewableSourceEditor(el, slice(), fakePlugin(), { onCommit: vi.fn() });
+    editor.start();
+    const ta = el.querySelector<HTMLTextAreaElement>('textarea')!;
+    expect(ta.value).toBe('A --> B');
+    expect(document.activeElement).toBe(ta);
+  });
+
+  it('start() hides the error chip initially', () => {
+    const el = contentEl('<div class="mermaid-container"></div>');
+    const editor = new PreviewableSourceEditor(el, slice(), fakePlugin(), { onCommit: vi.fn() });
+    editor.start();
+    expect(el.querySelector<HTMLElement>('.preview-source-error')!.hidden).toBe(true);
+  });
+
+  it('commit() calls plugin.applySourceToRaw with the textarea value and forwards to onCommit', () => {
+    const el = contentEl('<div class="mermaid-container"></div>');
+    const onCommit = vi.fn();
+    const editor = new PreviewableSourceEditor(el, slice(), fakePlugin(), { onCommit });
+    editor.start();
+    el.querySelector<HTMLTextAreaElement>('textarea')!.value = 'C --> D';
+    editor.commit();
+    expect(onCommit).toHaveBeenCalledWith('```mermaid\nC --> D\n```');
+  });
+
+  it('commit() is idempotent — a second call is a no-op', () => {
+    const el = contentEl('<div class="mermaid-container"></div>');
+    const onCommit = vi.fn();
+    const editor = new PreviewableSourceEditor(el, slice(), fakePlugin(), { onCommit });
+    editor.start();
+    editor.commit();
+    editor.commit();
+    expect(onCommit).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Two things in this branch:

1. **Live mermaid preview while editing** — clicking a \`\`\`mermaid\`\`\` block in edit mode now opens a preview-above-source surface. The rendered diagram stays visible at the top; a textarea sits below; the diagram re-renders ~250ms after each keystroke. Invalid mermaid syntax keeps the last good preview visible and surfaces the error in an inline chip between preview and textarea. \`Esc\` commits, click-away commits, race conditions are handled by per-call scratch containers and monotonic request IDs.

2. **Slice handle alignment for mermaid blocks** — \`slice-code:has(.mermaid-container)\` override sets \`--slice-handle-top: 0px\` since mermaid blocks render as \`<div.mermaid-container>\` rather than \`<pre>\`, and the 13px offset tuned for \`<pre>\`'s padding was wrong.

### Architecture (generalised)

The live preview is built on a new optional plugin capability — \`PreviewablePlugin\` — so any plugin that owns a fenced code block and can render to visual content can opt into the same editing surface. Mermaid is the first implementer; future plugins (math, graphviz, embedded HTML, etc.) get live preview for free by implementing four methods.

| Component | Role |
|---|---|
| \`PreviewablePlugin\` interface | Optional capability: \`matchesSlice\`, \`extractSource\`, \`renderPreview\`, \`applySourceToRaw\` |
| \`PluginManager.getPreviewablePlugins()\` | Returns enabled plugins implementing the capability |
| \`MermaidPlugin\` | Implements the contract — opens \`\`\`mermaid\`\`\` and \`~~~mermaid\`\`\` fences with info-string preservation |
| \`PreviewableSourceEditor\` (new) | Drives one editing session: layout, debounced re-render, race control, error chip, idempotent commit |
| \`EditModeController\` | New routing branch in \`startEdit\` opens the previewable editor for matching slices; shared \`applyRawCommit\` helper factored out so both the slim textarea and the previewable editor follow the same re-render path |

### Stats

- 9 files changed (3 added)
- 38 new tests; total suite 598 passing
- 22 commits, written task-by-task via TDD with subagent-driven implementation + two-stage review per task

### Spec and plan

- Design: \`docs/superpowers/specs/2026-05-19-mermaid-live-preview-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-19-mermaid-live-preview.md\`

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` — 598 passing across 30 files (38 new)
- [x] \`pnpm lint\` clean
- [ ] Manual: open a file with a mermaid diagram → enter edit mode (\`Cmd+E\`) → click the mermaid block → confirm preview-above-textarea surface
- [ ] Manual: edit the diagram source → preview updates ~250ms after typing pauses
- [ ] Manual: type invalid syntax → last good preview stays + red error chip appears with the mermaid error message
- [ ] Manual: fix the syntax → error chip disappears, preview updates
- [ ] Manual: \`Esc\` commits, slice re-renders with the new source
- [ ] Manual: click a non-mermaid code block (\`\`\`js\`\`\`) → opens regular raw textarea (no preview area)
- [ ] Manual: click a paragraph → still opens WYSIWYG inline editor
- [ ] Manual: hover any slice → handle dot grid sits aligned with the first text line for all block types

🤖 Generated with [Claude Code](https://claude.com/claude-code)